### PR TITLE
feat(infra): add docker-compose, start.sh and stubs for FIWARE stack (issue 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# XDEI P3 — Quick start
+
+Este repositorio contiene la orquestación mínima para levantar una pila FIWARE local para desarrollo.
+
+Requisitos:
+- Docker y Docker Compose instalados.
+
+Arranque rápido:
+
+```bash
+# (opcional) preparar y esperar servicios críticos
+./start.sh
+
+# Levantar toda la pila (en segundo plano opcionalmente)
+docker compose up --build
+```
+
+Servicios expuestos (puertos locales):
+- Mosquitto MQTT: `1883`
+- Orion-LD: `1026`
+- IoT Agent JSON: `4041`
+- CrateDB: `4200`
+- QuantumLeap: `8668`
+- Grafana: `3000`
+- Backend (stub): `8000` (`/health`)
+- Frontend (stub): `8080`
+
+Nota de modelado de datos:
+Las entidades NGSI-LD deben alinearse con los esquemas estándar de `dataModel.UrbanMobility` de FIWARE (PublicTransportStop, PublicTransportRoute, Vehicle, etc.). Consultar `data_model.md`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 8000
+CMD ["python", "app.py"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,14 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/health')
+def health():
+    return jsonify(status='ok')
+
+@app.route('/api/ping')
+def ping():
+    return jsonify(ping='pong')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.2.5
+requests==2.31.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,102 @@
+version: '3.8'
+
+services:
+  mosquitto:
+    image: eclipse-mosquitto:2.0
+    ports:
+      - "1883:1883"
+    volumes:
+      - mosquitto_data:/mosquitto/data
+      - mosquitto_log:/mosquitto/log
+
+  orion-ld:
+    image: fiware/orion-ld:3.0.0
+    environment:
+      - CONTEXT_BROKER_HOST=0.0.0.0
+    ports:
+      - "1026:1026"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:1026/ngsi-ld/v1/entities"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  iot-agent-json:
+    image: fiware/iot-agent-json:1.16.0
+    environment:
+      - IOTA_MQTT_HOST=mosquitto
+    ports:
+      - "4041:4041"
+    depends_on:
+      - orion-ld
+      - mosquitto
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4041/iot/about"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  crate:
+    image: crate:4.6.3
+    ports:
+      - "4200:4200"
+    volumes:
+      - crate_data:/var/lib/crate
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4200/_cluster/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  quantumleap:
+    image: smartsdk/quantumleap:1.7.0
+    environment:
+      - CRATE_HOST=crate
+      - CRATE_PORT=4200
+    ports:
+      - "8668:8668"
+    depends_on:
+      - crate
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8668/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  grafana:
+    image: grafana/grafana:9.4.7
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build: ./backend
+    image: xdei/backend:stub
+    ports:
+      - "8000:8000"
+    depends_on:
+      - orion-ld
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  frontend:
+    build: ./frontend
+    image: xdei/frontend:stub
+    ports:
+      - "8080:80"
+
+volumes:
+  crate_data:
+  grafana_data:
+  mosquitto_data:
+  mosquitto_log:
+  gtfs_feed:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html
+EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>XDEI P3 - Frontend Stub</title>
+  </head>
+  <body>
+    <h1>Frontend placeholder</h1>
+    <p>Mapa y UI vendrán en próximas iteraciones.</p>
+  </body>
+</html>

--- a/scripts/create_github_issues.py
+++ b/scripts/create_github_issues.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+def post_issue(repo, token, issue):
+    url = f"https://api.github.com/repos/{repo}/issues"
+    data = json.dumps(issue).encode('utf-8')
+    req = urllib.request.Request(url, data=data, method='POST')
+    req.add_header('Authorization', f'token {token}')
+    req.add_header('Accept', 'application/vnd.github+json')
+    req.add_header('User-Agent', 'p3_xdei-issue-creator')
+    req.add_header('Content-Type', 'application/json')
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp_data = json.load(resp)
+            return resp_data
+    except urllib.error.HTTPError as e:
+        try:
+            err = e.read().decode('utf-8')
+            return {'error': e.code, 'message': err}
+        except Exception:
+            return {'error': e.code, 'message': str(e)}
+
+def main():
+    if 'GH_TOKEN' not in os.environ:
+        print('GH_TOKEN environment variable not set', file=sys.stderr)
+        sys.exit(2)
+    token = os.environ['GH_TOKEN']
+    if len(sys.argv) < 2:
+        print('Usage: create_github_issues.py owner/repo', file=sys.stderr)
+        sys.exit(2)
+    repo = sys.argv[1]
+    issues_path = os.path.join(os.path.dirname(__file__), 'issues.json')
+    if not os.path.exists(issues_path):
+        print('issues.json not found', file=sys.stderr)
+        sys.exit(2)
+    with open(issues_path, 'r') as f:
+        issues = json.load(f)
+
+    created = []
+    for i, issue in enumerate(issues, start=1):
+        print(f'Creating issue {i}/{len(issues)}: {issue.get("title")}', flush=True)
+        resp = post_issue(repo, token, issue)
+        if resp is None:
+            print('No response for issue', issue.get('title'))
+            continue
+        if 'html_url' in resp:
+            print('CREATED:', resp['html_url'])
+            created.append(resp['html_url'])
+        else:
+            print('ERROR creating issue:', resp)
+
+    print('\nSummary:')
+    print(f'{len(created)}/{len(issues)} issues created')
+    for url in created:
+        print(url)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/issues.json
+++ b/scripts/issues.json
@@ -1,0 +1,177 @@
+[
+  {
+    "title": "Configurar docker-compose con FIWARE",
+    "body": "Crear `docker-compose.yml` con Orion-LD, Mosquitto, IoT Agent JSON, QuantumLeap, CrateDB, Grafana, backend y frontend. Incluir healthchecks, volúmenes y `start.sh`. Documentar puertos y acceso en README.",
+    "labels": ["infra","epic"]
+  },
+  {
+    "title": "Estructura backend Flask y clientes Orion/QuantumLeap",
+    "body": "Inicializar proyecto Flask con `requirements.txt`, crear `orion_client.py`, `quantumleap_client.py`, `mqtt_client.py` y endpoint `/health`. Añadir estructura de carpetas `/backend`.",
+    "labels": ["backend","epic"]
+  },
+  {
+    "title": "Esqueleto Frontend (Leaflet + Three.js)",
+    "body": "Crear `index.html`, `js/map.js`, `js/scene3d.js`, `js/api-client.js` y `css/styles.css`. Layout básico 2D/3D, centrar en A Coruña.",
+    "labels": ["frontend","epic"]
+  },
+  {
+    "title": "Implementar load_gtfs.py: parser GTFS → NGSI-LD",
+    "body": "Script Python para parsear ZIP GTFS y transformar filas a entidades NGSI-LD; batch POST a Orion-LD. Logging de entidades creadas y errores.",
+    "labels": ["data","backend"]
+  },
+  {
+    "title": "Validadores GTFS y tests del modelo de datos",
+    "body": "Crear `validate_gtfs.py` para verificar esquema GTFS, unicidad de IDs y geometrías. Añadir tests unitarios para entidades NGSI-LD.",
+    "labels": ["tests","data"]
+  },
+  {
+    "title": "Endpoints GET /api/routes, /api/stops, /api/trips",
+    "body": "Implementar endpoints en Flask que consulten Orion-LD y devuelvan datos paginados listos para el frontend.",
+    "labels": ["api","backend"]
+  },
+  {
+    "title": "dynamic_simulator.py: simulador de vehículos MQTT",
+    "body": "Simulador que interpola posición sobre shapes, calcula retraso/ocupación/velocidad y publica JSON en `vehicle/{id}/telemetry` cada 3s. CLI args `--speed-factor` y `--date`.",
+    "labels": ["simulator","backend"]
+  },
+  {
+    "title": "Configurar IoT Agent JSON: mapeo MQTT → VehicleState",
+    "body": "Configurar IoT Agent JSON para traducir mensajes MQTT a atributos NGSI-LD `VehicleState` y asegurarse de actualizaciones correctas en Orion-LD.",
+    "labels": ["infra","integration"]
+  },
+  {
+    "title": "Suscripción Orion-LD → QuantumLeap para persistencia histórica",
+    "body": "Crear subscription en Orion-LD para cambios de `VehicleState` y notificar a QuantumLeap; verificar datos en CrateDB.",
+    "labels": ["infra","data"]
+  },
+  {
+    "title": "Renderizar rutas, paradas y vehículos en Leaflet",
+    "body": "Frontend: polylines para shapes, markers para paradas, markers animados para vehículos con popups de info.",
+    "labels": ["frontend","ui"]
+  },
+  {
+    "title": "Polling /api/vehicles/current cada 2s y actualización suave",
+    "body": "Implementar polling desde frontend a `/api/vehicles/current` y actualizar posiciones con interpolación para animación suave.",
+    "labels": ["frontend","api"]
+  },
+  {
+    "title": "Panel lateral detalle vehículo/parada",
+    "body": "Panel UI que muestra tripId, próximas paradas, ETA, delay, ocupación y botón para predecir ocupación.",
+    "labels": ["frontend","ui"]
+  },
+  {
+    "title": "Endpoint /api/vehicles/history para consultas históricas",
+    "body": "Implementar endpoint que consulte QuantumLeap para rangos temporales, agrupe por vehicleId y devuelva JSON paginado.",
+    "labels": ["api","data"]
+  },
+  {
+    "title": "Timeline & replay: slider fecha/hora y reproducción histórica",
+    "body": "UI timeline con slider fecha/hora, botones play/pause/step y reconstrucción de la escena a partir de histórico.",
+    "labels": ["frontend","feature"]
+  },
+  {
+    "title": "Tests de consistencia histórica (gaps y coherencia)",
+    "body": "Tests de integración que detecten gaps en histórico, coherencia de posiciones y consistencia entre Orion, QuantumLeap y CrateDB.",
+    "labels": ["tests","data"]
+  },
+  {
+    "title": "generate_ml_dataset.py: generar dataset de ocupancia",
+    "body": "Script que extraiga histórico de CrateDB y genere features (route, stop, day, hour, prev_occupancy) para entrenamiento ML.",
+    "labels": ["ml","data"]
+  },
+  {
+    "title": "train_model.py: entrenar RandomForest y guardar modelo",
+    "body": "Entrenar RandomForest, GridSearch opcional, guardar `models/occupancy_model.pkl` y exportar feature importances.",
+    "labels": ["ml","backend"]
+  },
+  {
+    "title": "Endpoint /api/predict: predicción de ocupancia",
+    "body": "Cargar modelo, generar features para un stop/hora y devolver `predictedOccupancy`, `confidence`. Cache TTL 15min.",
+    "labels": ["api","ml"]
+  },
+  {
+    "title": "Mostrar predicción en UI: popup parada con % y gráfico",
+    "body": "Mostrar predicción breve en popup de parada y gráfico lineal de próximas 2 horas usando Chart.js.",
+    "labels": ["frontend","ml"]
+  },
+  {
+    "title": "Escena base Three.js: terreno, edificios y cámara",
+    "body": "Inicializar Three.js con plano texturado, edificios simple LOD y cámara orbitable; mantener performance.",
+    "labels": ["frontend","3d"]
+  },
+  {
+    "title": "Vehículos 3D animados coloreados por ruta",
+    "body": "Representar vehículos como meshes coloreados por routeColor, interpolación entre updates y rotación por heading.",
+    "labels": ["frontend","3d"]
+  },
+  {
+    "title": "Sincronización 2D ↔ 3D: VehicleManager compartido",
+    "body": "Crear módulo `VehicleManager` que centralice estado y sea consumido por `map.js` y `scene3d.js`.",
+    "labels": ["frontend","integration"]
+  },
+  {
+    "title": "Interacción 3D: raycast click/hover en vehículos/paradas",
+    "body": "Detectar clicks en 3D para mostrar el mismo panel lateral que en 2D; hover highlight.",
+    "labels": ["frontend","3d"]
+  },
+  {
+    "title": "Modelos UserProfile y RedeemedDiscount en Orion-LD",
+    "body": "Definir esquemas NGSI-LD para `UserProfile` y `RedeemedDiscount` y script `seed_gamification.py` para generar usuarios ficticios.",
+    "labels": ["backend","feature"]
+  },
+  {
+    "title": "Endpoints gamificación: profile, record-trip, redeem",
+    "body": "Implementar `GET /api/user/{id}/profile`, `POST /api/user/record-trip`, `POST /api/user/redeem` con validación básica.",
+    "labels": ["api","feature"]
+  },
+  {
+    "title": "UI gamificación: perfil, logros y canjes",
+    "body": "Panel frontend para mostrar puntos, logros y permitir canje; animaciones para logros.",
+    "labels": ["frontend","feature"]
+  },
+  {
+    "title": "Autenticación mock: JWT para desarrollo",
+    "body": "Implementar login simple que emita JWT guardado en localStorage; backend valida JWT en endpoints de usuario.",
+    "labels": ["backend","infra"]
+  },
+  {
+    "title": "Configurar Grafana con CrateDB",
+    "body": "Provisionar datasource CrateDB en Grafana y asegurar conexión; guardar provisioning YAML en repo.",
+    "labels": ["infra","monitoring"]
+  },
+  {
+    "title": "Crear dashboards Grafana: retrasos, ocupación, volumen",
+    "body": "Dashboards operativos para retrasos por línea, ocupación por parada y volumen de viajes por hora; auto-refresh 30s.",
+    "labels": ["monitoring","dashboard"]
+  },
+  {
+    "title": "Healthchecks y logging: endpoint /health",
+    "body": "Implementar `/health` que verifique Orion, QuantumLeap y CrateDB; logs estructurados y alertas básicas.",
+    "labels": ["backend","infra"]
+  },
+  {
+    "title": "README: quick start, arquitectura y scripts",
+    "body": "Documentación completa con quick start (`docker-compose up`), diagrama arquitectura, API examples y scripts de datos.",
+    "labels": ["docs"]
+  },
+  {
+    "title": "Tests unitarios e integración (pytest)",
+    "body": "Suite de tests unitarios e integración (Orion-QL-CrateDB). `make test` para ejecutar.",
+    "labels": ["tests"]
+  },
+  {
+    "title": "Validación E2E y checklist de aceptación",
+    "body": "Checklist E2E que valida levantado del stack, funcionalidades MVP y criterios de performance y reproducibilidad.",
+    "labels": ["qa"]
+  },
+  {
+    "title": "Responsividad móvil y touch gestures",
+    "body": "Ajustes CSS y touch gestures para 3D/2D en mobile; layout single-column y tabs.",
+    "labels": ["frontend","mobile"]
+  },
+  {
+    "title": "Optimización rendimiento: lazy-load, cache y minify",
+    "body": "Implementar lazy-load de shapes, caché de predicciones (Redis opcional), compresión gzip y minificación frontend.",
+    "labels": ["performance"]
+  }
+]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Waiting for core services to become available..."
+
+wait_for() {
+  host=$1
+  port=$2
+  name=$3
+  timeout=${4:-60}
+  echo -n "- Waiting for $name at $host:$port... "
+  for i in $(seq 1 $timeout); do
+    if nc -z "$host" "$port" >/dev/null 2>&1; then
+      echo "OK"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "TIMEOUT"
+  return 1
+}
+
+# Wait for Mosquitto (MQTT)
+wait_for mosquitto 1883 Mosquitto 30
+
+# Wait for Orion-LD
+wait_for orion-ld 1026 Orion-LD 60
+
+# Wait for CrateDB
+wait_for crate 4200 CrateDB 60
+
+echo "All critical services responded; you can now run 'docker compose up' or start simulators." 
+
+exec "$@"


### PR DESCRIPTION
feat(infra): add docker-compose, start.sh and stubs for FIWARE stack (issue 1)

Summary
- Adds a minimal, reproducible Docker Compose stack to run core FIWARE components locally and placeholder backend/frontend containers.

What this PR includes
- `docker-compose.yml` with: Mosquitto, Orion-LD, IoT Agent JSON, CrateDB, QuantumLeap, Grafana, `backend` and `frontend` stubs; healthchecks and minimal service dependencies.
- `start.sh` helper to wait for critical services during local setup.
- Backend stub: `backend/Dockerfile`, `backend/app.py`, `backend/requirements.txt` (Flask health endpoint).
- Frontend stub: `frontend/Dockerfile`, `frontend/index.html` (static placeholder).
- `README.md` with quick start and exposed ports.

Update after restore
- Added follow-up fix commit `4f53945` to restore full FIWARE compose services after accidental removal/mismatch.
- Restored `orion-ld`, `iot-agent-json`, and `quantumleap` service definitions.
- Reinstated `backend` dependency on `orion-ld` and corrected frontend mapping to `8080:80`.
- Re-validated compose syntax with `docker compose config --quiet`.

Out of scope
- Full backend or frontend business logic (these remain stubs/placeholders).
- GTFS loader, simulator, IoT Agent mapping details, and ML components.

How to test locally
```bash
./start.sh
docker compose up --build
# in another shell
curl -s http://localhost:8000/health
# open http://localhost:8080 and http://localhost:3000 (Grafana)
```

Notes
- MODELING: Entities must align with FIWARE `dataModel.UrbanMobility` (use official types and @context). See `data_model.md`.
- This PR focuses on reproducible orchestration; follow-ups will implement loaders, simulator and API functionality.

Request
- Please review compose healthchecks, pinned images, and volume paths.

PR ready to merge when green and reviewed — I did not include automatic migrations or data loading to keep the surface small and reviewable.