### PR TITLE
Añadir simulador dinámico de vehículos (Issue #7)

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,7 @@
+"""Backend package initializer for the XDEI project.
+
+This file makes the `backend` folder a Python package so tests and modules
+can import `backend.*` directly.
+"""
+
+__all__ = []

--- a/backend/config.py
+++ b/backend/config.py
@@ -70,6 +70,13 @@ class AppConfig:
     flask_env: str
 
 
+@dataclass
+class SimulatorConfig:
+    """Simulator configuration."""
+    publish_interval_seconds: int
+    default_speed_factor: float
+
+
 class Settings:
     """Central settings manager."""
     
@@ -117,6 +124,12 @@ class Settings:
             flask_port=int(os.getenv("FLASK_PORT", "8000")),
             flask_env=os.getenv("FLASK_ENV", "development"),
         )
+
+        # Simulator defaults
+        self.simulator = SimulatorConfig(
+            publish_interval_seconds=int(os.getenv("SIMULATOR_INTERVAL", "3")),
+            default_speed_factor=float(os.getenv("SIMULATOR_SPEED_FACTOR", "1.0")),
+        )
     
     def get_fiware_headers(self) -> dict:
         """Get standard FIWARE headers for API requests."""
@@ -128,3 +141,4 @@ class Settings:
 
 # Global settings instance
 settings = Settings()
+

--- a/backend/dynamic_simulator.py
+++ b/backend/dynamic_simulator.py
@@ -1,0 +1,120 @@
+"""Dynamic vehicle simulator (Issue 7).
+
+Publishes simple telemetry messages to MQTT topics `vehicle/{id}/telemetry`.
+This implementation is intentionally small and testable; it uses GTFS feed
+shapes to interpolate positions and computes basic telemetry fields.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+import datetime
+import logging
+import random
+from typing import Optional
+
+from clients.mqtt import MQTTClient
+from config import settings
+from load_gtfs import read_gtfs_feed
+from utils.simulator_utils import (
+    interpolate_along_line,
+    cumulative_distances,
+    trip_duration_seconds,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def publish_telemetry(mqtt_client: MQTTClient, vehicle_id: str, payload: dict) -> None:
+    topic = f"vehicle/{vehicle_id}/telemetry"
+    mqtt_client.publish(topic, payload)
+
+
+def simulate_once(mqtt_client: MQTTClient, vehicle_id: str, lon: float, lat: float, trip_id: str) -> dict:
+    """Build and publish a single telemetry payload (testable helper)."""
+    payload = {
+        "vehicle_id": vehicle_id,
+        "trip_id": trip_id,
+        "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        "lon": lon,
+        "lat": lat,
+        "speed": round(random.uniform(5.0, 15.0), 2),
+        "delay": 0,
+        "occupancy": random.randint(5, 80),
+    }
+    publish_telemetry(mqtt_client, vehicle_id, payload)
+    return payload
+
+
+def run_simulator(gtfs_zip: str, date: Optional[str], speed_factor: float, interval: Optional[int]) -> None:
+    feed = read_gtfs_feed(gtfs_zip)
+
+    # Minimal selection: use all trips that reference shapes
+    trips_with_shape = [t for t in feed.trips if t.get("shape_id")]
+    if not trips_with_shape:
+        LOGGER.error("No trips with shapes found in GTFS feed")
+        return
+
+    mqtt_client = MQTTClient(
+        host=settings.mqtt.host,
+        port=settings.mqtt.port,
+        timeout=settings.mqtt.timeout,
+        keepalive=settings.mqtt.keepalive,
+    )
+    mqtt_client.connect()
+
+    try:
+        # For demo: simulate first trip only in a simple loop
+        trip = trips_with_shape[0]
+        shape_id = trip.get("shape_id")
+        # find shape entity in feed.shapes
+        shapes = [s for s in feed.shapes if s.get("shape_id") == shape_id]
+        if not shapes:
+            LOGGER.error("Shape points not found for shape_id %s", shape_id)
+            return
+        # build coordinates list: shapes file has shape_pt_lon, shape_pt_lat
+        ordered = sorted(shapes, key=lambda r: float(r.get("shape_pt_sequence", "0")))
+        coords = [(float(r["shape_pt_lon"]), float(r["shape_pt_lat"])) for r in ordered]
+        cum = cumulative_distances(coords)
+        total_m = cum[-1] if cum else 0.0
+
+        # get stop_times for trip to estimate duration
+        stop_times = [st for st in feed.stop_times if st.get("trip_id") == trip.get("trip_id")]
+        duration = trip_duration_seconds(stop_times) or 60
+
+        start_real = time.time()
+        while True:
+            elapsed = (time.time() - start_real) * speed_factor
+            frac = (elapsed % duration) / max(1, duration)
+            dist = frac * total_m
+            lon, lat = interpolate_along_line(coords, dist)
+            vehicle_id = f"veh_{trip.get('trip_id')}"
+            simulate_once(mqtt_client, vehicle_id, lon, lat, trip.get("trip_id"))
+            time.sleep(interval or settings.simulator.publish_interval_seconds)
+
+    finally:
+        mqtt_client.disconnect()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run dynamic vehicle simulator from GTFS feed")
+    parser.add_argument("gtfs_zip", help="Path to GTFS ZIP file")
+    parser.add_argument("--date", help="Date to simulate (YYYY-MM-DD)")
+    parser.add_argument("--speed-factor", type=float, default=settings.simulator.default_speed_factor)
+    parser.add_argument("--interval", type=int, help="Publish interval seconds (overrides config)")
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        run_simulator(args.gtfs_zip, args.date, args.speed_factor, args.interval)
+    except Exception as exc:
+        LOGGER.exception("Simulator failed: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/utils/simulator_utils.py
+++ b/backend/utils/simulator_utils.py
@@ -1,0 +1,86 @@
+"""Utilities for the dynamic vehicle simulator.
+
+Lightweight geospatial helpers (haversine/interpolation) and GTFS helpers
+used by the simulator.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple
+import math
+
+
+def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return distance in meters between two lat/lon points using Haversine."""
+    R = 6371000.0
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi/2.0)**2 + math.cos(phi1)*math.cos(phi2)*math.sin(dlambda/2.0)**2
+    c = 2*math.atan2(math.sqrt(a), math.sqrt(1-a))
+    return R * c
+
+
+def cumulative_distances(coords: List[Tuple[float, float]]) -> List[float]:
+    """Given a list of (lon, lat) coordinates return cumulative distances (meters).
+
+    Returns list with same length where first element is 0.0
+    """
+    dists = [0.0]
+    for i in range(1, len(coords)):
+        lon1, lat1 = coords[i-1]
+        lon2, lat2 = coords[i]
+        d = haversine(lat1, lon1, lat2, lon2)
+        dists.append(dists[-1] + d)
+    return dists
+
+
+def interpolate_along_line(coords: List[Tuple[float, float]], distance_m: float) -> Tuple[float, float]:
+    """Interpolate a point at `distance_m` meters along the polyline `coords`.
+
+    Coordinates are list of (lon, lat). Returns (lon, lat).
+    If distance_m <= 0 returns first point; if >= total length returns last point.
+    """
+    if not coords:
+        raise ValueError("coords must contain at least one point")
+    if len(coords) == 1:
+        return coords[0]
+
+    cum = cumulative_distances(coords)
+    total = cum[-1]
+    if distance_m <= 0 or total == 0:
+        return coords[0]
+    if distance_m >= total:
+        return coords[-1]
+
+    # find segment
+    for i in range(1, len(cum)):
+        if cum[i] >= distance_m:
+            seg_start = cum[i-1]
+            seg_end = cum[i]
+            frac = (distance_m - seg_start) / (seg_end - seg_start) if seg_end > seg_start else 0.0
+            lon1, lat1 = coords[i-1]
+            lon2, lat2 = coords[i]
+            lon = lon1 + (lon2 - lon1) * frac
+            lat = lat1 + (lat2 - lat1) * frac
+            return (lon, lat)
+
+    return coords[-1]
+
+
+def parse_time_to_seconds(timestr: str) -> int:
+    """Parse HH:MM:SS (or H:MM:SS) into seconds since midnight."""
+    parts = timestr.split(":")
+    if len(parts) != 3:
+        raise ValueError("time string must be HH:MM:SS")
+    h, m, s = (int(p) for p in parts)
+    return h * 3600 + m * 60 + s
+
+
+def trip_duration_seconds(stop_times: List[dict]) -> int:
+    """Return duration in seconds for a trip using first departure to last arrival."""
+    if not stop_times:
+        return 0
+    first = stop_times[0].get("departure_time") or stop_times[0].get("arrival_time")
+    last = stop_times[-1].get("arrival_time") or stop_times[-1].get("departure_time")
+    return max(0, parse_time_to_seconds(last) - parse_time_to_seconds(first))

--- a/tests/test_simulator_interpolation.py
+++ b/tests/test_simulator_interpolation.py
@@ -1,0 +1,15 @@
+from backend.utils.simulator_utils import interpolate_along_line, cumulative_distances
+
+
+def test_cumulative_and_interpolate():
+    # simple two-point line: (lon,lat)
+    coords = [(0.0, 0.0), (0.0, 0.009)]  # ~1km north
+    cum = cumulative_distances(coords)
+    assert len(cum) == 2
+    total = cum[-1]
+    assert total > 900 and total < 1100
+
+    # halfway should be near the midpoint
+    mid = interpolate_along_line(coords, total / 2)
+    assert abs(mid[0] - 0.0) < 1e-6
+    assert abs(mid[1] - 0.0045) < 0.001

--- a/tests/test_simulator_publish.py
+++ b/tests/test_simulator_publish.py
@@ -1,0 +1,27 @@
+from backend.dynamic_simulator import publish_telemetry, simulate_once
+
+
+class MockMQTT:
+    def __init__(self):
+        self.pubs = []
+
+    def publish(self, topic, payload, qos=1):
+        self.pubs.append((topic, payload))
+
+
+def test_publish_telemetry_and_simulate_once():
+    mock = MockMQTT()
+    payload = {"foo": "bar"}
+    publish_telemetry(mock, "v1", payload)
+    assert mock.pubs
+    topic, sent = mock.pubs[-1]
+    assert topic == "vehicle/v1/telemetry"
+
+    # simulate_once should publish and return payload dict
+    mock2 = MockMQTT()
+    out = simulate_once(mock2, "v2", 1.0, 2.0, "trip_1")
+    assert isinstance(out, dict)
+    assert mock2.pubs
+    t, p = mock2.pubs[-1]
+    assert t == "vehicle/v2/telemetry"
+    assert p["trip_id"] == "trip_1"

--- a/tests/test_simulator_trip_duration.py
+++ b/tests/test_simulator_trip_duration.py
@@ -1,0 +1,9 @@
+from backend.utils.simulator_utils import trip_duration_seconds
+
+
+def test_trip_duration_seconds():
+    stop_times = [
+        {"departure_time": "08:00:00"},
+        {"arrival_time": "08:15:00"},
+    ]
+    assert trip_duration_seconds(stop_times) == 15 * 60


### PR DESCRIPTION
Añade un simulador dinámico de vehículos que publica telemetría MQTT.

Cambios principales:\n- : CLI y bucle de simulación (publica en ).\n- : helpers de geolocalización e interpolación.\n- : añade configuración  (intervalo y speed-factor).\n- : convierte  en paquete.\n- : añade tests unitarios para interpolación, duración de trip y publicación.

Cómo probar localmente:\n1. Crear venv: \n2. Instalar deps: Requirement already satisfied: Flask==3.0.0 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 1)) (3.0.0)
Requirement already satisfied: Werkzeug==3.0.0 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 2)) (3.0.0)
Requirement already satisfied: requests==2.31.0 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 3)) (2.31.0)
Requirement already satisfied: paho-mqtt==1.6.1 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 4)) (1.6.1)
Requirement already satisfied: python-dotenv==1.0.0 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 5)) (1.0.0)
Requirement already satisfied: tenacity==8.2.3 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 6)) (8.2.3)
Requirement already satisfied: pytest==7.4.3 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 7)) (7.4.3)
Requirement already satisfied: pytest-mock==3.12.0 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 8)) (3.12.0)
Requirement already satisfied: pandas==2.1.3 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 9)) (2.1.3)
Requirement already satisfied: python-dateutil==2.8.2 in ./.venv/lib/python3.12/site-packages (from -r backend/requirements.txt (line 10)) (2.8.2)
Requirement already satisfied: Jinja2>=3.1.2 in ./.venv/lib/python3.12/site-packages (from Flask==3.0.0->-r backend/requirements.txt (line 1)) (3.1.6)
Requirement already satisfied: itsdangerous>=2.1.2 in ./.venv/lib/python3.12/site-packages (from Flask==3.0.0->-r backend/requirements.txt (line 1)) (2.2.0)
Requirement already satisfied: click>=8.1.3 in ./.venv/lib/python3.12/site-packages (from Flask==3.0.0->-r backend/requirements.txt (line 1)) (8.3.3)
Requirement already satisfied: blinker>=1.6.2 in ./.venv/lib/python3.12/site-packages (from Flask==3.0.0->-r backend/requirements.txt (line 1)) (1.9.0)
Requirement already satisfied: MarkupSafe>=2.1.1 in ./.venv/lib/python3.12/site-packages (from Werkzeug==3.0.0->-r backend/requirements.txt (line 2)) (3.0.3)
Requirement already satisfied: charset-normalizer<4,>=2 in ./.venv/lib/python3.12/site-packages (from requests==2.31.0->-r backend/requirements.txt (line 3)) (3.4.7)
Requirement already satisfied: idna<4,>=2.5 in ./.venv/lib/python3.12/site-packages (from requests==2.31.0->-r backend/requirements.txt (line 3)) (3.13)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./.venv/lib/python3.12/site-packages (from requests==2.31.0->-r backend/requirements.txt (line 3)) (2.6.3)
Requirement already satisfied: certifi>=2017.4.17 in ./.venv/lib/python3.12/site-packages (from requests==2.31.0->-r backend/requirements.txt (line 3)) (2026.4.22)
Requirement already satisfied: iniconfig in ./.venv/lib/python3.12/site-packages (from pytest==7.4.3->-r backend/requirements.txt (line 7)) (2.3.0)
Requirement already satisfied: packaging in ./.venv/lib/python3.12/site-packages (from pytest==7.4.3->-r backend/requirements.txt (line 7)) (26.2)
Requirement already satisfied: pluggy<2.0,>=0.12 in ./.venv/lib/python3.12/site-packages (from pytest==7.4.3->-r backend/requirements.txt (line 7)) (1.6.0)
Requirement already satisfied: numpy<2,>=1.26.0 in ./.venv/lib/python3.12/site-packages (from pandas==2.1.3->-r backend/requirements.txt (line 9)) (1.26.4)
Requirement already satisfied: pytz>=2020.1 in ./.venv/lib/python3.12/site-packages (from pandas==2.1.3->-r backend/requirements.txt (line 9)) (2026.1.post1)
Requirement already satisfied: tzdata>=2022.1 in ./.venv/lib/python3.12/site-packages (from pandas==2.1.3->-r backend/requirements.txt (line 9)) (2026.2)
Requirement already satisfied: six>=1.5 in ./.venv/lib/python3.12/site-packages (from python-dateutil==2.8.2->-r backend/requirements.txt (line 10)) (1.17.0) o al menos \n3. Ejecutar tests: ........................................................................ [ 75%]
.......................                                                  [100%]
=============================== warnings summary ===============================
tests/test_simulator_publish.py::test_publish_telemetry_and_simulate_once
  /home/lucia/xdei/p3/backend/dynamic_simulator.py:38: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
95 passed, 1 warning in 6.32s\n4. Ejecutar simulador (con Mosquitto en ): \n
Checklist:\n- [x] Código implementado y probado localmente (unit tests pasan)\n- [ ] Revisión de código\n- [ ] Merge tras aprobación