### PR TITLE
Conectar simulador de vehículos con IoT Agent JSON (Issue #8)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY app.py .
+COPY . .
 EXPOSE 8000
 CMD ["python", "app.py"]

--- a/backend/clients/mqtt.py
+++ b/backend/clients/mqtt.py
@@ -98,12 +98,13 @@ class MQTTClient:
         
         logger.debug(f"Received MQTT message on {topic}")
         
-        # Execute registered callback for this topic if exists
-        if topic in self._callbacks:
-            try:
-                self._callbacks[topic](topic, payload)
-            except Exception as e:
-                logger.error(f"Error in MQTT message callback for {topic}: {e}")
+        # Execute any callback whose subscription filter matches the topic.
+        for topic_filter, callback in self._callbacks.items():
+            if topic_filter == topic or mqtt.topic_matches_sub(topic_filter, topic):
+                try:
+                    callback(topic, payload)
+                except Exception as e:
+                    logger.error(f"Error in MQTT message callback for {topic_filter}: {e}")
     
     def _on_publish(self, client, userdata, mid):
         """Callback for when message is published."""
@@ -231,7 +232,7 @@ class MQTTClient:
             if result[0] != mqtt.MQTT_ERR_SUCCESS:
                 raise MQTTClientError(f"Subscribe failed with code {result[0]}")
             
-            # Store callback for this topic
+            # Store callback for this topic or subscription filter.
             self._callbacks[topic] = callback
             
             logger.info(f"Subscribed to {topic}")

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest configuration for backend tests.
+
+Ensures the backend package layout is importable when pytest is launched from
+the repository root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))

--- a/backend/tests/test_mqtt_client.py
+++ b/backend/tests/test_mqtt_client.py
@@ -185,6 +185,25 @@ class TestMQTTClientCallbacks:
         
         assert callback_called["called"] is True
         assert callback_called["args"] == ("test/topic", "test payload")
+
+    def test_on_message_matches_wildcard_subscription(self, mqtt_client):
+        """Test that wildcard subscriptions receive matching topics."""
+        callback_called = {"called": False, "args": None}
+
+        def test_callback(topic, payload):
+            callback_called["called"] = True
+            callback_called["args"] = (topic, payload)
+
+        mqtt_client._callbacks["vehicle/+/telemetry"] = test_callback
+
+        mock_msg = Mock()
+        mock_msg.topic = "vehicle/bus-7/telemetry"
+        mock_msg.payload = b'{"speed": 10}'
+
+        mqtt_client._on_message(None, None, mock_msg)
+
+        assert callback_called["called"] is True
+        assert callback_called["args"] == ("vehicle/bus-7/telemetry", '{"speed": 10}')
     
     def test_on_connect_success(self, mqtt_client):
         """Test on_connect callback with success."""

--- a/backend/tests/test_vehicle_bridge.py
+++ b/backend/tests/test_vehicle_bridge.py
@@ -1,0 +1,111 @@
+"""Tests for the telemetry bridge from simulator MQTT to IoT Agent JSON."""
+
+import json
+from unittest.mock import Mock, patch
+
+from vehicle_bridge import (
+    BridgeConfig,
+    VehicleTelemetryBridge,
+    build_vehicle_state_measure,
+    parse_vehicle_id,
+)
+
+
+def test_parse_vehicle_id():
+    assert parse_vehicle_id("vehicle/bus-17/telemetry") == "bus-17"
+    assert parse_vehicle_id("vehicle/bus-17/status") is None
+
+
+def test_build_vehicle_state_measure_maps_telemetry_to_ngsi_ld():
+    measure = build_vehicle_state_measure(
+        "bus-17",
+        {
+            "lon": -3.7,
+            "lat": 40.4,
+            "speed": 27.5,
+            "delay": 90,
+            "occupancy": 42,
+            "trip_id": "trip-12",
+            "timestamp": "2026-01-01T12:00:00Z",
+        },
+        previous_position=(-3.71, 40.39),
+    )
+
+    assert measure["id"] == "urn:ngsi-ld:VehicleState:bus-17"
+    assert measure["type"] == "VehicleState"
+    assert measure["measure_id"]["value"] == "urn:ngsi-ld:VehicleState:bus-17"
+    assert measure["measure_type"]["value"] == "VehicleState"
+    assert measure["currentPosition"]["type"] == "GeoProperty"
+    assert measure["currentPosition"]["value"]["coordinates"] == [-3.7, 40.4]
+    assert measure["delaySeconds"]["value"] == 90
+    assert measure["occupancy"]["value"] == 42
+    assert measure["speedKmh"]["value"] == 27.5
+    assert measure["trip"]["object"] == "urn:ngsi-ld:GtfsTrip:trip-12"
+
+
+def test_bridge_forwards_telemetry_to_iot_agent_topic():
+    bridge = VehicleTelemetryBridge(
+        BridgeConfig(
+            mqtt_host="localhost",
+            mqtt_port=1883,
+            mqtt_timeout=5,
+            mqtt_keepalive=60,
+            mqtt_prefix="json",
+            telemetry_prefix="vehicle",
+            default_key="1234",
+            iot_agent_url="http://iot-agent-json:4041",
+            context_broker_url="http://orion-ld:1026",
+            fiware_headers={"Fiware-Service": "smartgondor", "Fiware-ServicePath": "/gardens"},
+            entity_type="VehicleState",
+        )
+    )
+    bridge.mqtt_client = Mock()
+
+    bridge.handle_message(
+        "vehicle/bus-17/telemetry",
+        json.dumps(
+            {
+                "lon": -3.7,
+                "lat": 40.4,
+                "speed": 27.5,
+                "delay": 90,
+                "occupancy": 42,
+                "trip_id": "trip-12",
+                "timestamp": "2026-01-01T12:00:00Z",
+            }
+        ),
+    )
+
+    bridge.mqtt_client.publish.assert_called_once()
+    topic, payload = bridge.mqtt_client.publish.call_args.args[:2]
+    assert topic == "json/1234/bus-17/attrs"
+    assert payload["type"] == "VehicleState"
+    assert payload["status"]["value"] == "in_transit"
+
+
+@patch("vehicle_bridge.requests.post")
+def test_provision_iot_agent_group_uses_ngsi_ld_payload(mock_post):
+    mock_post.return_value.status_code = 201
+    bridge = VehicleTelemetryBridge(
+        BridgeConfig(
+            mqtt_host="localhost",
+            mqtt_port=1883,
+            mqtt_timeout=5,
+            mqtt_keepalive=60,
+            mqtt_prefix="json",
+            telemetry_prefix="vehicle",
+            default_key="1234",
+            iot_agent_url="http://iot-agent-json:4041",
+            context_broker_url="http://orion-ld:1026",
+            fiware_headers={"Fiware-Service": "smartgondor", "Fiware-ServicePath": "/gardens"},
+            entity_type="VehicleState",
+        )
+    )
+
+    bridge.provision_iot_agent_group()
+
+    assert mock_post.called
+    request_kwargs = mock_post.call_args.kwargs
+    assert request_kwargs["json"]["services"][0]["payloadType"] == "ngsild"
+    assert request_kwargs["json"]["services"][0]["entityNameExp"] == "measure_id"
+    assert request_kwargs["json"]["services"][0]["cbHost"] == "http://orion-ld:1026"

--- a/backend/vehicle_bridge.py
+++ b/backend/vehicle_bridge.py
@@ -1,0 +1,254 @@
+"""MQTT bridge from simulator telemetry to FIWARE IoT Agent JSON.
+
+The simulator publishes compact vehicle telemetry on `vehicle/{id}/telemetry`.
+This bridge converts those messages into NGSI-LD vehicle state measures and
+forwards them to the IoT Agent JSON MQTT topic contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+from clients.mqtt import MQTTClient
+from config import settings
+from utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+NGSI_LD_CONTEXT = ["https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _bearing(previous: Tuple[float, float], current: Tuple[float, float]) -> float:
+    """Calculate a simple compass bearing in degrees for consecutive points."""
+    prev_lon, prev_lat = previous
+    lon, lat = current
+    lon1 = math.radians(prev_lon)
+    lon2 = math.radians(lon)
+    lat1 = math.radians(prev_lat)
+    lat2 = math.radians(lat)
+    delta_lon = lon2 - lon1
+
+    x = math.sin(delta_lon) * math.cos(lat2)
+    y = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(delta_lon)
+    bearing = math.degrees(math.atan2(x, y))
+    return round((bearing + 360.0) % 360.0, 2)
+
+
+def parse_vehicle_id(topic: str, prefix: str = "vehicle") -> Optional[str]:
+    """Extract the vehicle id from a telemetry topic."""
+    parts = topic.strip("/").split("/")
+    if len(parts) == 3 and parts[0] == prefix and parts[2] == "telemetry":
+        return parts[1]
+    return None
+
+
+def build_vehicle_state_measure(
+    vehicle_id: str,
+    telemetry: Dict[str, Any],
+    previous_position: Optional[Tuple[float, float]] = None,
+) -> Dict[str, Any]:
+    """Transform simulator telemetry into an NGSI-LD VehicleState measure."""
+    lon = float(telemetry["lon"])
+    lat = float(telemetry["lat"])
+    heading = telemetry.get("heading")
+    if heading is None and previous_position is not None:
+        heading = _bearing(previous_position, (lon, lat))
+    if heading is None:
+        heading = 0.0
+
+    trip_id = telemetry.get("trip_id")
+    measure: Dict[str, Any] = {
+        "id": f"urn:ngsi-ld:VehicleState:{vehicle_id}",
+        "type": "VehicleState",
+        "@context": NGSI_LD_CONTEXT,
+        "measure_id": {
+            "type": "Text",
+            "value": f"urn:ngsi-ld:VehicleState:{vehicle_id}",
+        },
+        "measure_type": {
+            "type": "Text",
+            "value": "VehicleState",
+        },
+        "currentPosition": {
+            "type": "GeoProperty",
+            "value": {
+                "type": "Point",
+                "coordinates": [lon, lat],
+            },
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        },
+        "delaySeconds": {
+            "type": "Property",
+            "value": telemetry.get("delay", 0),
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        },
+        "occupancy": {
+            "type": "Property",
+            "value": telemetry.get("occupancy", 0),
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        },
+        "speedKmh": {
+            "type": "Property",
+            "value": telemetry.get("speed", 0),
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        },
+        "heading": {
+            "type": "Property",
+            "value": heading,
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        },
+        "status": {
+            "type": "Property",
+            "value": telemetry.get("status", "in_transit"),
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        },
+    }
+
+    if trip_id:
+        measure["trip"] = {
+            "type": "Relationship",
+            "object": f"urn:ngsi-ld:GtfsTrip:{trip_id}",
+            "observedAt": telemetry.get("timestamp", _now_iso()),
+        }
+
+    return measure
+
+
+@dataclass
+class BridgeConfig:
+    mqtt_host: str = field(default_factory=lambda: os.getenv("MQTT_HOST", settings.mqtt.host))
+    mqtt_port: int = field(default_factory=lambda: int(os.getenv("MQTT_PORT", str(settings.mqtt.port))))
+    mqtt_timeout: int = field(default_factory=lambda: int(os.getenv("MQTT_TIMEOUT", str(settings.mqtt.timeout))))
+    mqtt_keepalive: int = field(default_factory=lambda: int(os.getenv("MQTT_KEEPALIVE", str(settings.mqtt.keepalive))))
+    mqtt_prefix: str = field(default_factory=lambda: os.getenv("BRIDGE_MQTT_PREFIX", "json"))
+    telemetry_prefix: str = field(default_factory=lambda: os.getenv("BRIDGE_TELEMETRY_PREFIX", "vehicle"))
+    default_key: str = field(default_factory=lambda: os.getenv("BRIDGE_DEFAULT_KEY", "1234"))
+    iot_agent_url: str = field(default_factory=lambda: os.getenv("IOTA_AGENT_URL", "http://iot-agent-json:4041"))
+    context_broker_url: str = field(default_factory=lambda: os.getenv("ORION_URL", settings.orion.url))
+    fiware_headers: Dict[str, str] = field(default_factory=settings.get_fiware_headers)
+    entity_type: str = "VehicleState"
+
+
+class VehicleTelemetryBridge:
+    """Bridge simulator telemetry into FIWARE IoT Agent JSON."""
+
+    def __init__(self, config: Optional[BridgeConfig] = None):
+        self.config = config or BridgeConfig()
+        self.mqtt_client = MQTTClient(
+            host=self.config.mqtt_host,
+            port=self.config.mqtt_port,
+            timeout=self.config.mqtt_timeout,
+            keepalive=self.config.mqtt_keepalive,
+        )
+        self._last_positions: Dict[str, Tuple[float, float]] = {}
+
+    def provision_iot_agent_group(self) -> None:
+        """Provision a reusable MQTT group for NGSI-LD measures."""
+        payload = {
+            "services": [
+                {
+                    "resource": "/iot/json",
+                    "apikey": self.config.default_key,
+                    "entity_type": self.config.entity_type,
+                    "cbHost": self.config.context_broker_url,
+                    "commands": [],
+                    "lazy": [],
+                    "attributes": [],
+                    "static_attributes": [],
+                    "transport": "MQTT",
+                    "payloadType": "ngsild",
+                    "entityNameExp": "measure_id",
+                }
+            ]
+        }
+
+        last_error: Optional[Exception] = None
+        for _ in range(30):
+            try:
+                response = requests.post(
+                    f"{self.config.iot_agent_url.rstrip('/')}/iot/services",
+                    json=payload,
+                    headers=self.config.fiware_headers,
+                    timeout=15,
+                )
+                if response.status_code in (200, 201, 409):
+                    return
+                response.raise_for_status()
+            except Exception as exc:  # pragma: no cover - retry loop is integration safety
+                last_error = exc
+                time.sleep(2)
+
+        if last_error:
+            raise last_error
+
+    def _publish_measure(self, vehicle_id: str, telemetry: Dict[str, Any]) -> Dict[str, Any]:
+        previous = self._last_positions.get(vehicle_id)
+        measure = build_vehicle_state_measure(vehicle_id, telemetry, previous)
+        self._last_positions[vehicle_id] = (
+            float(telemetry["lon"]),
+            float(telemetry["lat"]),
+        )
+
+        topic = f"{self.config.mqtt_prefix}/{self.config.default_key}/{vehicle_id}/attrs"
+        self.mqtt_client.publish(topic, measure)
+        logger.info("Forwarded telemetry for %s to %s", vehicle_id, topic)
+        return measure
+
+    def handle_message(self, topic: str, payload: str) -> None:
+        vehicle_id = parse_vehicle_id(topic, self.config.telemetry_prefix)
+        if not vehicle_id:
+            logger.debug("Ignoring MQTT topic %s", topic)
+            return
+
+        telemetry = json.loads(payload)
+        self._publish_measure(vehicle_id, telemetry)
+
+    def start(self) -> None:
+        self.provision_iot_agent_group()
+        self.mqtt_client.connect()
+        self.mqtt_client.subscribe(
+            f"{self.config.telemetry_prefix}/+/telemetry",
+            self.handle_message,
+        )
+        logger.info(
+            "Vehicle bridge listening on %s:%s and forwarding telemetry to IoT Agent JSON",
+            self.config.mqtt_host,
+            self.config.mqtt_port,
+        )
+
+    def stop(self) -> None:
+        self.mqtt_client.disconnect()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Bridge vehicle telemetry into IoT Agent JSON")
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    parser.parse_args(argv)
+    bridge = VehicleTelemetryBridge()
+    bridge.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        bridge.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest configuration for the repository.
+
+Adds the backend package root to sys.path so tests can import the backend
+modules consistently from the repository root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parent / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,15 @@ services:
   iot-agent-json:
     image: fiware/iot-agent-json:1.16.0
     environment:
+      - IOTA_CB_HOST=orion-ld
+      - IOTA_CB_PORT=1026
+      - IOTA_NORTH_PORT=4041
+      - IOTA_REGISTRY_TYPE=memory
       - IOTA_MQTT_HOST=mosquitto
+      - IOTA_MQTT_PORT=1883
+      - IOTA_DEFAULT_KEY=1234
+      - IOTA_DEFAULT_TRANSPORT=MQTT
+      - IOTA_PROVIDER_URL=http://iot-agent-json:4041
     ports:
       - "4041:4041"
     depends_on:
@@ -70,6 +78,24 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  vehicle-bridge:
+    build: ./backend
+    image: xdei/backend:stub
+    command: ["python", "vehicle_bridge.py"]
+    environment:
+      - MQTT_HOST=mosquitto
+      - MQTT_PORT=1883
+      - ORION_HOST=orion-ld
+      - ORION_PORT=1026
+      - IOTA_AGENT_URL=http://iot-agent-json:4041
+      - BRIDGE_DEFAULT_KEY=1234
+      - FIWARE_SERVICE=smartgondor
+      - FIWARE_SERVICEPATH=/gardens
+    depends_on:
+      - mosquitto
+      - orion-ld
+      - iot-agent-json
 
   quantumleap:
     image: smartsdk/quantumleap:1.7.0


### PR DESCRIPTION
Resumen: añade un bridge MQTT que convierte telemetría de vehículos en medidas NGSI-LD VehicleState, provisiona el contrato MQTT esperado por IoT Agent JSON y ajusta docker-compose, la imagen backend y los tests. Validación: pytest tests/test_simulator_publish.py backend/tests/test_mqtt_client.py backend/tests/test_vehicle_bridge.py; docker compose config.