### PR TITLE
Implementar suscripción histórica Orion-LD → QuantumLeap (Issue #9)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,9 +4,11 @@ XDEI Backend - Flask Application
 Main application entry point with health check and service status endpoints.
 """
 
-from flask import Flask, jsonify
+import time
 from datetime import datetime, timezone
-from clients.orion import OrionClient
+
+from flask import Flask, jsonify
+from clients.orion import OrionClient, OrionClientConflict, OrionClientError
 from clients.quantumleap import QuantumLeapClient
 from clients.mqtt import MQTTClient
 from config import settings
@@ -38,6 +40,70 @@ mqtt_client = MQTTClient(
     timeout=settings.mqtt.timeout,
     keepalive=settings.mqtt.keepalive,
 )
+
+VEHICLE_STATE_HISTORY_SUBSCRIPTION_ID = "urn:ngsi-ld:Subscription:vehicle-state-history"
+VEHICLE_STATE_HISTORY_WATCHED_ATTRS = [
+    "currentPosition",
+    "delaySeconds",
+    "occupancy",
+    "speedKmh",
+    "heading",
+    "status",
+    "trip",
+]
+
+
+def build_vehicle_state_history_subscription() -> dict:
+    """Build the NGSI-LD subscription used to persist VehicleState changes."""
+    return {
+        "id": VEHICLE_STATE_HISTORY_SUBSCRIPTION_ID,
+        "type": "Subscription",
+        "description": "Persist VehicleState changes in QuantumLeap",
+        "entities": [
+            {
+                "type": "VehicleState",
+            }
+        ],
+        "watchedAttributes": VEHICLE_STATE_HISTORY_WATCHED_ATTRS,
+        "notification": {
+            "attributes": VEHICLE_STATE_HISTORY_WATCHED_ATTRS,
+            "endpoint": {
+                "uri": f"{settings.quantumleap.url.rstrip('/')}/v2/notify",
+                "accept": "application/ld+json",
+            },
+        },
+    }
+
+
+def ensure_vehicle_state_history_subscription(max_attempts: int = 30, retry_delay_seconds: int = 2) -> bool:
+    """Ensure the historical subscription exists before the backend starts serving traffic."""
+    subscription = build_vehicle_state_history_subscription()
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            existing_subscriptions = orion_client.get_subscriptions()
+            if any(item.get("id") == subscription["id"] for item in existing_subscriptions):
+                logger.info("VehicleState historical subscription already exists")
+                return False
+
+            orion_client.create_subscription(subscription)
+            logger.info("Created VehicleState historical subscription")
+            return True
+
+        except OrionClientConflict:
+            logger.info("VehicleState historical subscription already exists")
+            return False
+        except OrionClientError as exc:
+            logger.warning(
+                "Attempt %s/%s to create VehicleState historical subscription failed: %s",
+                attempt,
+                max_attempts,
+                exc,
+            )
+            if attempt < max_attempts:
+                time.sleep(retry_delay_seconds)
+
+    raise RuntimeError("Unable to create VehicleState historical subscription")
 
 
 @app.route('/health', methods=['GET'])
@@ -150,6 +216,7 @@ def ping():
 
 if __name__ == '__main__':
     logger.info(f"Starting XDEI Backend on {settings.app.flask_host}:{settings.app.flask_port}")
+    ensure_vehicle_state_history_subscription()
     app.run(
         host=settings.app.flask_host,
         port=settings.app.flask_port,

--- a/backend/clients/orion.py
+++ b/backend/clients/orion.py
@@ -8,7 +8,7 @@ Includes automatic retry logic with exponential backoff and proper error handlin
 import json
 from typing import Any, Dict, List, Optional
 import requests
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -26,6 +26,11 @@ class OrionConnectionError(OrionClientError):
 
 class OrionClientNotFound(OrionClientError):
     """Raised when requested entity is not found (404)."""
+    pass
+
+
+class OrionClientConflict(OrionClientError):
+    """Raised when a resource already exists (409)."""
     pass
 
 
@@ -74,6 +79,7 @@ class OrionClient:
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type(OrionConnectionError),
     )
     def _request(
         self,
@@ -97,6 +103,7 @@ class OrionClient:
             requests.HTTPError: For HTTP errors
         """
         url = f"{self.base_url}{path}"
+        response = None
         
         try:
             logger.debug(f"{method} {url}")
@@ -116,9 +123,11 @@ class OrionClient:
             logger.error(f"Connection error to {url}: {e}")
             raise OrionConnectionError(f"Connection failed: {e}") from e
         except requests.exceptions.HTTPError as e:
-            if response.status_code == 404:
-                raise OrionClientNotFound(f"Entity not found: {response.text}") from e
-            logger.error(f"HTTP error {response.status_code}: {response.text}")
+            error_response = getattr(e, "response", None) or response
+            if error_response is not None and error_response.status_code == 404:
+                raise OrionClientNotFound(f"Entity not found: {error_response.text}") from e
+            if error_response is not None:
+                logger.error(f"HTTP error {error_response.status_code}: {error_response.text}")
             raise
     
     def get_entities(
@@ -307,6 +316,96 @@ class OrionClient:
                 # Continue with next batch instead of stopping
         
         return stats
+
+    def get_subscriptions(self) -> List[Dict[str, Any]]:
+        """
+        List subscriptions registered in Orion-LD.
+
+        Returns:
+            List of subscription dicts.
+        """
+        try:
+            response = self._request(
+                "GET",
+                "/ngsi-ld/v1/subscriptions",
+                headers=self._get_headers(),
+            )
+            subscriptions = response.json()
+            logger.info(f"Retrieved {len(subscriptions)} subscriptions")
+            return subscriptions
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON response: {e}")
+            raise OrionClientError(f"Invalid JSON response: {e}") from e
+
+    def create_subscription(self, subscription: Dict[str, Any]) -> str:
+        """
+        Create a subscription in Orion-LD.
+
+        Args:
+            subscription: NGSI-LD subscription dict.
+
+        Returns:
+            Subscription ID.
+
+        Raises:
+            OrionClientError: If creation fails.
+        """
+        if "type" not in subscription:
+            raise OrionClientError("Subscription must include 'type'")
+
+        if subscription.get("type") != "Subscription":
+            raise OrionClientError("Subscription type must be 'Subscription'")
+
+        path = "/ngsi-ld/v1/subscriptions"
+
+        try:
+            response = self._request(
+                "POST",
+                path,
+                headers=self._get_headers(),
+                json=subscription,
+            )
+            location = response.headers.get("Location", "")
+            if location:
+                return location.rstrip("/").split("/")[-1]
+            if "id" in subscription:
+                return subscription["id"]
+            return ""
+
+        except requests.exceptions.HTTPError as e:
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            if status_code == 409:
+                raise OrionClientConflict(f"Subscription already exists: {e}") from e
+            logger.error(f"Failed to create subscription: {e}")
+            raise OrionClientError(f"Failed to create subscription: {e}") from e
+
+    def delete_subscription(self, subscription_id: str) -> None:
+        """
+        Delete a subscription from Orion-LD.
+
+        Args:
+            subscription_id: Subscription ID.
+
+        Raises:
+            OrionClientNotFound: If subscription does not exist.
+            OrionClientError: If deletion fails.
+        """
+        path = f"/ngsi-ld/v1/subscriptions/{subscription_id}"
+
+        try:
+            self._request(
+                "DELETE",
+                path,
+                headers=self._get_headers(),
+            )
+            logger.info(f"Deleted subscription {subscription_id}")
+
+        except OrionClientNotFound:
+            raise
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"Failed to delete subscription {subscription_id}: {e}")
+            raise OrionClientError(f"Failed to delete subscription: {e}") from e
     
     def delete_entity(self, entity_id: str) -> None:
         """

--- a/backend/clients/quantumleap.py
+++ b/backend/clients/quantumleap.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 import requests
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -75,6 +75,7 @@ class QuantumLeapClient:
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type(QuantumLeapConnectionError),
     )
     def _request(
         self,
@@ -98,6 +99,7 @@ class QuantumLeapClient:
             requests.HTTPError: For HTTP errors
         """
         url = f"{self.base_url}{path}"
+        response = None
         
         try:
             logger.debug(f"{method} {url}")
@@ -117,9 +119,11 @@ class QuantumLeapClient:
             logger.error(f"Connection error to QuantumLeap {url}: {e}")
             raise QuantumLeapConnectionError(f"Connection failed: {e}") from e
         except requests.exceptions.HTTPError as e:
-            if response.status_code == 404:
-                raise QuantumLeapNotFound(f"Data not found: {response.text}") from e
-            logger.error(f"HTTP error {response.status_code}: {response.text}")
+            error_response = getattr(e, "response", None) or response
+            if error_response is not None and error_response.status_code == 404:
+                raise QuantumLeapNotFound(f"Data not found: {error_response.text}") from e
+            if error_response is not None:
+                logger.error(f"HTTP error {error_response.status_code}: {error_response.text}")
             raise
     
     def get_time_series(

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -5,7 +5,7 @@ Unit tests for health check endpoint.
 import pytest
 import json
 from unittest.mock import Mock, patch
-from app import app
+from app import app, ensure_vehicle_state_history_subscription, build_vehicle_state_history_subscription
 
 
 @pytest.fixture
@@ -102,3 +102,28 @@ class TestPingEndpoint:
         assert response.status_code == 200
         data = json.loads(response.data)
         assert data['ping'] == 'pong'
+
+
+class TestVehicleStateSubscriptionBootstrap:
+    """Test startup bootstrap for VehicleState historical subscription."""
+
+    @patch('app.orion_client')
+    def test_bootstrap_creates_subscription_when_missing(self, mock_orion):
+        """Should create the subscription if it does not exist yet."""
+        mock_orion.get_subscriptions.return_value = []
+        mock_orion.create_subscription.return_value = build_vehicle_state_history_subscription()['id']
+
+        result = ensure_vehicle_state_history_subscription(max_attempts=1, retry_delay_seconds=0)
+
+        assert result is True
+        mock_orion.create_subscription.assert_called_once()
+
+    @patch('app.orion_client')
+    def test_bootstrap_is_idempotent_when_subscription_exists(self, mock_orion):
+        """Should not create a duplicate subscription if it already exists."""
+        mock_orion.get_subscriptions.return_value = [build_vehicle_state_history_subscription()]
+
+        result = ensure_vehicle_state_history_subscription(max_attempts=1, retry_delay_seconds=0)
+
+        assert result is False
+        mock_orion.create_subscription.assert_not_called()

--- a/backend/tests/test_orion_client.py
+++ b/backend/tests/test_orion_client.py
@@ -10,6 +10,7 @@ from clients.orion import (
     OrionClientError,
     OrionConnectionError,
     OrionClientNotFound,
+    OrionClientConflict,
 )
 
 
@@ -185,6 +186,74 @@ class TestOrionClientBatchOperations:
         assert result['total'] == 250
         assert result['batches'] == 3
         assert mock_request.call_count == 3
+
+
+class TestOrionClientSubscriptions:
+    """Test subscription CRUD operations."""
+
+    @patch('clients.orion.requests.Session.request')
+    def test_get_subscriptions(self, mock_request, orion_client, mock_response):
+        """Test listing subscriptions."""
+        subscriptions = [
+            {"id": "sub-1", "type": "Subscription"},
+            {"id": "sub-2", "type": "Subscription"},
+        ]
+        mock_response.json.return_value = subscriptions
+        mock_request.return_value = mock_response
+
+        result = orion_client.get_subscriptions()
+
+        assert result == subscriptions
+        mock_request.assert_called_once()
+
+    @patch('clients.orion.requests.Session.request')
+    def test_create_subscription(self, mock_request, orion_client):
+        """Test creating a subscription returns the subscription ID."""
+        response = Mock()
+        response.status_code = 201
+        response.json.return_value = {}
+        response.headers = {"Location": "http://localhost:1026/ngsi-ld/v1/subscriptions/sub-123"}
+        mock_request.return_value = response
+
+        subscription = {
+            "id": "sub-123",
+            "type": "Subscription",
+            "entities": [{"type": "VehicleState"}],
+            "notification": {"endpoint": {"uri": "http://quantumleap:8668/v2/notify"}},
+        }
+
+        result = orion_client.create_subscription(subscription)
+
+        assert result == "sub-123"
+        mock_request.assert_called_once()
+
+    def test_create_subscription_invalid_type(self, orion_client):
+        """Test subscription validation rejects invalid types."""
+        with pytest.raises(OrionClientError):
+            orion_client.create_subscription({"id": "sub-1", "type": "Device"})
+
+    @patch('clients.orion.requests.Session.request')
+    def test_create_subscription_conflict(self, mock_request, orion_client):
+        """Test subscription conflict is mapped to OrionClientConflict."""
+        import requests
+
+        response = Mock()
+        response.status_code = 409
+        response.text = "Conflict"
+        http_error = requests.exceptions.HTTPError(response=response)
+        mock_request.side_effect = http_error
+
+        with pytest.raises(OrionClientConflict):
+            orion_client.create_subscription({"id": "sub-1", "type": "Subscription"})
+
+    @patch('clients.orion.requests.Session.request')
+    def test_delete_subscription(self, mock_request, orion_client, mock_response):
+        """Test deleting a subscription."""
+        mock_request.return_value = mock_response
+
+        orion_client.delete_subscription("sub-1")
+
+        mock_request.assert_called_once()
 
 
 class TestOrionClientHealthCheck:


### PR DESCRIPTION
Resumen:\n- Añade CRUD de subscriptions en el cliente Orion.\n- Crea en el arranque una suscripción idempotente para VehicleState hacia QuantumLeap.\n- Corrige el manejo de HTTPError y limita los retries a fallos de conexión.\n- Añade tests para subscriptions y bootstrap del backend.\n\nValidación local:\n- .venv/bin/pytest backend/tests/test_orion_client.py backend/tests/test_health.py -q\n- .venv/bin/pytest backend/tests/test_quantumleap_client.py -q\n\nChecklist:\n- [x] Código implementado y probado localmente\n- [ ] Revisión de código\n- [ ] Merge tras aprobación