### PR TITLE
Implementar polling /api/vehicles/current y animación suave (Issue #11)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,21 +1,44 @@
 <!doctype html>
 <html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>XDEI P3 - Frontend</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="static/css/map.css" />
+
     <script>
-      // BACKEND_BASE_URL will be substituted at container start by the Docker entrypoint.
-      // If not substituted, it defaults to an empty string (use same-origin).
+      // BACKEND_BASE_URL may be substituted at container start by the Docker entrypoint.
+      // If still unresolved, compute a local fallback.
       window.BACKEND_BASE_URL = '__BACKEND_BASE_URL__';
     </script>
     <script>
       (function () {
-        if (window.BACKEND_BASE_URL !== undefined) return;
+        var current = window.BACKEND_BASE_URL;
+        var unresolved = !current || current === '__BACKEND_BASE_URL__';
+
+        if (!unresolved) {
+          try {
+            var parsed = new URL(current, location.origin);
+            if (parsed.hostname === 'backend') {
+              // Make docker-internal hostname reachable from host browser.
+              window.BACKEND_BASE_URL = parsed.protocol + '//' + location.hostname + (parsed.port ? ':' + parsed.port : '');
+            }
+          } catch (e) {
+            // Keep original value if parsing fails.
+          }
+          return;
+        }
+
         try {
           var host = location.hostname;
           var port = location.port || '';
-          // If frontend served on 8081 (compose) or 8001 (local static serve), backend is likely on 8002 for local testing
+
+          // For local static frontend ports, default backend to port 8002.
           if (port === '8081' || port === '8001') {
             window.BACKEND_BASE_URL = location.protocol + '//' + host + ':8002';
           } else {
-            // default to empty which keeps same-origin (relative) requests
+            // Default to same-origin relative paths.
             window.BACKEND_BASE_URL = '';
           }
         } catch (e) {
@@ -23,6 +46,20 @@
         }
       })();
     </script>
+  </head>
+  <body>
+    <div id="hud">
+      <div id="map-status" class="hud-pill" aria-live="polite">Inicializando mapa…</div>
+      <div class="hud-legend" aria-hidden="true">
+        <span><i class="legend-swatch legend-route"></i>Rutas</span>
+        <span><i class="legend-swatch legend-stop"></i>Paradas</span>
+        <span><i class="legend-swatch legend-vehicle"></i>Vehículos</span>
+      </div>
+    </div>
+
+    <div id="map"></div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="static/js/api-client.js"></script>
     <script src="static/js/map.js"></script>
     <script>

--- a/frontend/static/js/api-client.js
+++ b/frontend/static/js/api-client.js
@@ -94,8 +94,69 @@
     }
   }
 
+  async function loadCurrentVehicles() {
+    const vehiclesResponse = await fetchJson('/api/vehicles/current');
+    return Array.isArray(vehiclesResponse.vehicles) ? vehiclesResponse.vehicles : [];
+  }
+
+  function createVehiclePolling(options) {
+    const settings = options || {};
+    const intervalMs = Number.isFinite(settings.intervalMs) && settings.intervalMs > 0 ? settings.intervalMs : 2000;
+    const onData = typeof settings.onData === 'function' ? settings.onData : function () {};
+    const onError = typeof settings.onError === 'function' ? settings.onError : function () {};
+
+    let timerId = null;
+    let inFlight = false;
+
+    async function tick() {
+      if (inFlight) {
+        return;
+      }
+
+      inFlight = true;
+      try {
+        const vehicles = await loadCurrentVehicles();
+        onData(vehicles);
+      } catch (error) {
+        onError(error);
+      } finally {
+        inFlight = false;
+      }
+    }
+
+    function start() {
+      if (timerId) {
+        return;
+      }
+
+      tick();
+      timerId = window.setInterval(tick, intervalMs);
+    }
+
+    function stop() {
+      if (!timerId) {
+        return;
+      }
+
+      window.clearInterval(timerId);
+      timerId = null;
+      inFlight = false;
+    }
+
+    return {
+      start,
+      stop,
+      isRunning: function () {
+        return Boolean(timerId);
+      },
+      intervalMs,
+    };
+  }
+
   global.MapApiClient = {
     loadMapData,
+    loadCurrentVehicles,
+    createVehiclePolling,
     sampleData: () => cloneData(SAMPLE_DATA),
   };
 })(window);

--- a/frontend/static/js/map.js
+++ b/frontend/static/js/map.js
@@ -16,11 +16,28 @@ function initMap() {
   const routeLayer = L.layerGroup().addTo(map);
   const stopLayer = L.layerGroup().addTo(map);
   const vehicleLayer = L.layerGroup().addTo(map);
+  const vehicleMarkers = new Map();
+  const vehicleStates = new Map();
+  const vehiclePollingIntervalMs = 2000;
+
+  let mapFitted = false;
+  let pollingController = null;
+  let animationFrameId = null;
+  const counters = {
+    routes: 0,
+    stops: 0,
+    vehicles: 0,
+  };
 
   function setStatus(message) {
     if (statusEl) {
       statusEl.textContent = message;
     }
+  }
+
+  function refreshStatus(suffix) {
+    const base = `Rutas ${counters.routes} · Paradas ${counters.stops} · Vehículos ${counters.vehicles}`;
+    setStatus(suffix ? `${base} · ${suffix}` : base);
   }
 
   function normalizeColor(value, fallback) {
@@ -65,6 +82,54 @@ function initMap() {
       iconAnchor: [9, 9],
       popupAnchor: [0, -10],
     });
+  }
+
+  function clamp01(value) {
+    return Math.max(0, Math.min(1, value));
+  }
+
+  function lerp(start, end, t) {
+    return start + (end - start) * t;
+  }
+
+  function animateVehicles(timestamp) {
+    let keepAnimating = false;
+
+    vehicleStates.forEach((state) => {
+      if (!state || !state.marker || !state.startLatLng || !state.targetLatLng) {
+        return;
+      }
+
+      const duration = Math.max(1, state.endTime - state.startTime);
+      const progress = clamp01((timestamp - state.startTime) / duration);
+      const lat = lerp(state.startLatLng.lat, state.targetLatLng.lat, progress);
+      const lng = lerp(state.startLatLng.lng, state.targetLatLng.lng, progress);
+      const interpolated = L.latLng(lat, lng);
+
+      state.currentLatLng = interpolated;
+      state.marker.setLatLng(interpolated);
+
+      if (progress < 1) {
+        keepAnimating = true;
+      } else {
+        state.startLatLng = state.targetLatLng;
+      }
+    });
+
+    if (keepAnimating) {
+      animationFrameId = window.requestAnimationFrame(animateVehicles);
+      return;
+    }
+
+    animationFrameId = null;
+  }
+
+  function ensureAnimationLoop() {
+    if (animationFrameId !== null) {
+      return;
+    }
+
+    animationFrameId = window.requestAnimationFrame(animateVehicles);
   }
 
   function routePopup(route) {
@@ -154,23 +219,72 @@ function initMap() {
   }
 
   function renderVehicles(vehicles) {
-    vehicleLayer.clearLayers();
     const bounds = L.latLngBounds([]);
+    const activeVehicleIds = new Set();
+    const now = window.performance && typeof window.performance.now === 'function'
+      ? window.performance.now()
+      : Date.now();
 
     vehicles.forEach((vehicle) => {
       if (!Array.isArray(vehicle.currentPosition) || vehicle.currentPosition.length < 2) {
         return;
       }
 
-      const marker = L.marker([vehicle.currentPosition[1], vehicle.currentPosition[0]], {
+      const vehicleId = vehicle.id || vehicle.vehicleId;
+      if (!vehicleId) {
+        return;
+      }
+
+      activeVehicleIds.add(vehicleId);
+      const latLng = L.latLng(vehicle.currentPosition[1], vehicle.currentPosition[0]);
+
+      const existingMarker = vehicleMarkers.get(vehicleId);
+      if (existingMarker) {
+        const state = vehicleStates.get(vehicleId);
+        const currentLatLng = state && state.currentLatLng ? state.currentLatLng : existingMarker.getLatLng();
+
+        if (state) {
+          state.startLatLng = currentLatLng;
+          state.targetLatLng = latLng;
+          state.startTime = now;
+          state.endTime = now + vehiclePollingIntervalMs;
+        }
+
+        existingMarker.setPopupContent(vehiclePopup(vehicle));
+        bounds.extend(latLng);
+        return;
+      }
+
+      const marker = L.marker(latLng, {
         icon: markerIcon('map-marker--vehicle', vehicle.vehicleId ? vehicle.vehicleId.replace(/^bus-/, '') : 'V'),
         title: vehicle.vehicleId || vehicle.id,
       });
 
       marker.bindPopup(vehiclePopup(vehicle));
       marker.addTo(vehicleLayer);
-      bounds.extend(marker.getLatLng());
+      vehicleMarkers.set(vehicleId, marker);
+      vehicleStates.set(vehicleId, {
+        marker,
+        currentLatLng: latLng,
+        startLatLng: latLng,
+        targetLatLng: latLng,
+        startTime: now,
+        endTime: now + vehiclePollingIntervalMs,
+      });
+      bounds.extend(latLng);
     });
+
+    vehicleMarkers.forEach((marker, vehicleId) => {
+      if (activeVehicleIds.has(vehicleId)) {
+        return;
+      }
+
+      vehicleLayer.removeLayer(marker);
+      vehicleMarkers.delete(vehicleId);
+      vehicleStates.delete(vehicleId);
+    });
+
+    ensureAnimationLoop();
 
     return bounds;
   }
@@ -191,17 +305,50 @@ function initMap() {
     }
   }
 
-  function updateMap(data) {
+  function updateMap(data, options) {
+    const settings = options || {};
     const routeBounds = renderRoutes(data.routes || []);
     const stopBounds = renderStops(data.stops || []);
     const vehicleBounds = renderVehicles(data.vehicles || []);
 
-    fitToData([routeBounds, stopBounds, vehicleBounds]);
+    if (!mapFitted || settings.fitBounds) {
+      fitToData([routeBounds, stopBounds, vehicleBounds]);
+      mapFitted = true;
+    }
 
-    const routeCount = (data.routes || []).length;
-    const stopCount = (data.stops || []).length;
-    const vehicleCount = (data.vehicles || []).length;
-    setStatus(`Rutas ${routeCount} · Paradas ${stopCount} · Vehículos ${vehicleCount}`);
+    counters.routes = (data.routes || []).length;
+    counters.stops = (data.stops || []).length;
+    counters.vehicles = (data.vehicles || []).length;
+    refreshStatus('actualizando cada 2s');
+  }
+
+  function updateVehicles(vehicles) {
+    renderVehicles(vehicles || []);
+    counters.vehicles = (vehicles || []).length;
+    refreshStatus('actualizando cada 2s');
+  }
+
+  function startVehiclePolling() {
+    if (!window.MapApiClient || typeof window.MapApiClient.createVehiclePolling !== 'function') {
+      return;
+    }
+
+    if (pollingController && pollingController.isRunning()) {
+      return;
+    }
+
+    pollingController = window.MapApiClient.createVehiclePolling({
+      intervalMs: vehiclePollingIntervalMs,
+      onData: function (vehicles) {
+        updateVehicles(vehicles);
+      },
+      onError: function (error) {
+        console.warn('Vehicle polling failed:', error);
+        refreshStatus('reintentando conexion');
+      },
+    });
+
+    pollingController.start();
   }
 
   function loadAndRender() {
@@ -212,11 +359,15 @@ function initMap() {
       : Promise.resolve(window.MapApiClient ? window.MapApiClient.sampleData() : { routes: [], stops: [], vehicles: [] });
 
     loader
-      .then((data) => updateMap(data))
+      .then((data) => {
+        updateMap(data, { fitBounds: true });
+        startVehiclePolling();
+      })
       .catch((error) => {
         console.warn('Unable to render map data:', error);
         if (window.MapApiClient && typeof window.MapApiClient.sampleData === 'function') {
-          updateMap(window.MapApiClient.sampleData());
+          updateMap(window.MapApiClient.sampleData(), { fitBounds: true });
+          startVehiclePolling();
         }
         setStatus('Mostrando datos de muestra');
       });
@@ -224,6 +375,17 @@ function initMap() {
 
   window.addEventListener('resize', function () {
     map.invalidateSize();
+  });
+
+  window.addEventListener('beforeunload', function () {
+    if (pollingController) {
+      pollingController.stop();
+    }
+
+    if (animationFrameId !== null) {
+      window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = null;
+    }
   });
 
   loadAndRender();


### PR DESCRIPTION
Resumen:
- Añade polling configurable cada 2s para /api/vehicles/current en frontend/static/js/api-client.js con start/stop, protección inFlight y callback de errores.
- Refactoriza frontend/static/js/map.js para reutilizar markers de vehículos por ID (sin recrearlos por tick), gestionar altas/bajas y mantener estado interno.
- Incorpora interpolación suave con requestAnimationFrame entre snapshots de polling para reducir saltos visuales.
- Integra limpieza de recursos en beforeunload (stop polling + cancelAnimationFrame).
- Repara y completa frontend/index.html (estructura, HUD/status, carga de Leaflet y resolución robusta de BACKEND_BASE_URL).

Validación realizada:
- node --check frontend/static/js/api-client.js
- node --check frontend/static/js/map.js
- Diagnóstico VS Code sin errores en frontend/index.html, frontend/static/js/api-client.js, frontend/static/js/map.js.
- Verificación funcional en navegador con rutas API mockeadas: 4 llamadas a /api/vehicles/current en ~5.6s, estado "actualizando cada 2s", y movimiento del marcador confirmado (moved=true).

Notas:
- PR creada sin merge, según solicitado.
- Queda un archivo no relacionado sin tocar: .github/PR-45-BODY.txt.