### PR TITLE
UI gamificación: perfil, logros y canjes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -86,6 +86,17 @@
         </div>
         <div id="detail-panel-body" class="detail-panel__body"></div>
       </aside>
+
+      <aside id="gamification-panel" class="gamification-panel" aria-label="Panel de gamificación">
+        <div class="gamification-panel__header">
+          <div>
+            <div class="gamification-panel__eyebrow">Gamificación</div>
+            <h2 class="gamification-panel__title">Perfil, logros y canjes</h2>
+          </div>
+          <div id="gamification-status" class="gamification-panel__status">Listo para cargar</div>
+        </div>
+        <div id="gamification-panel-body" class="gamification-panel__body"></div>
+      </aside>
     </main>
 
     <script>
@@ -96,6 +107,7 @@
       });
     </script>
     <script src="static/js/api-client.js"></script>
+    <script src="static/js/gamification-manager.js"></script>
     <script src="static/js/vehicle-manager.js"></script>
     <script type="module" src="static/js/scene3d.js"></script>
   </body>

--- a/frontend/static/css/map.css
+++ b/frontend/static/css/map.css
@@ -24,18 +24,13 @@ html, body {
   height: 100%;
 }
 
-#detail-panel {
+#detail-panel,
+#gamification-panel {
   position: fixed;
-  top: 86px;
   right: 16px;
   width: min(380px, calc(100vw - 32px));
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   max-height: calc(100vh - 108px);
-
-#app-shell {
-  position: relative;
-  min-height: 100vh;
-}
   z-index: 1100;
   display: flex;
   flex-direction: column;
@@ -48,6 +43,19 @@ html, body {
   border: 1px solid rgba(255, 255, 255, 0.12);
   box-shadow: 0 22px 60px rgba(0, 0, 0, 0.32);
   overflow: hidden;
+}
+
+#detail-panel {
+  top: 86px;
+}
+
+#gamification-panel {
+  bottom: 16px;
+}
+
+#app-shell {
+  position: relative;
+  min-height: 100vh;
 }
 
 .hud-stack {
@@ -256,19 +264,323 @@ html, body {
   margin-top: 6px;
 }
 
+.gamification-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gamification-panel__eyebrow {
+  font: 700 0.72rem/1.1 system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(245, 247, 251, 0.56);
+  margin-bottom: 6px;
+}
+
+.gamification-panel__title {
+  margin: 0;
+  font: 700 1.06rem/1.2 system-ui, sans-serif;
+}
+
+.gamification-panel__status {
+  align-self: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(245, 247, 251, 0.82);
+  font: 600 0.8rem/1.1 system-ui, sans-serif;
+}
+
+.gamification-panel__body {
+  overflow: auto;
+  display: grid;
+  gap: 12px;
+  padding-right: 2px;
+}
+
+.gamification-section {
+  display: grid;
+  gap: 10px;
+}
+
+.gamification-section__title {
+  margin: 0;
+  font: 700 0.82rem/1.1 system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 247, 251, 0.58);
+}
+
+.gamification-user-form,
+.gamification-form {
+  display: grid;
+  gap: 10px;
+}
+
+.gamification-form__grid,
+.gamification-summary,
+.gamification-achievement-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.gamification-summary {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gamification-summary__card,
+.gamification-empty,
+.gamification-error,
+.gamification-progress,
+.gamification-achievement,
+.gamification-history__item {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.gamification-summary__label,
+.gamification-summary__value,
+.gamification-empty__text,
+.gamification-progress__hint,
+.gamification-history__meta,
+.gamification-achievement__description,
+.gamification-achievement__requirement {
+  color: rgba(245, 247, 251, 0.78);
+  font: 500 0.92rem/1.45 system-ui, sans-serif;
+}
+
+.gamification-summary__label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 247, 251, 0.58);
+}
+
+.gamification-summary__value {
+  display: block;
+  font-size: 1.28rem;
+  font-weight: 700;
+  color: #f5f7fb;
+}
+
+.gamification-field {
+  display: grid;
+  gap: 4px;
+}
+
+.gamification-field span {
+  font: 600 0.75rem/1.1 system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 247, 251, 0.66);
+}
+
+.gamification-field input {
+  padding: 9px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f7fb;
+  font: 500 0.88rem/1.2 system-ui, sans-serif;
+}
+
+.gamification-field input:focus {
+  outline: none;
+  border-color: #ffb020;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.gamification-button {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: linear-gradient(180deg, #ffcf5a 0%, #ff9f1c 100%);
+  color: #102030;
+  font: 700 0.88rem/1.1 system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.gamification-button--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f5f7fb;
+}
+
+.gamification-button:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.gamification-progress,
+.gamification-error,
+.gamification-empty,
+.gamification-message {
+  display: grid;
+  gap: 10px;
+}
+
+.gamification-progress__header,
+.gamification-history__row,
+.gamification-achievement__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gamification-progress__track,
+.gamification-achievement__progress-track {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.gamification-progress__track span,
+.gamification-achievement__progress-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #ffcf5a 0%, #ff9f1c 100%);
+}
+
+.gamification-progress__hint {
+  margin: 0;
+}
+
+.gamification-achievement-grid {
+  grid-template-columns: 1fr;
+}
+
+.gamification-achievement {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.gamification-achievement--unlocked {
+  border-color: rgba(255, 176, 32, 0.36);
+  background: linear-gradient(180deg, rgba(255, 176, 32, 0.14) 0%, rgba(255, 255, 255, 0.05) 100%);
+}
+
+.gamification-achievement__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 1.2rem;
+}
+
+.gamification-achievement__content {
+  display: grid;
+  gap: 8px;
+}
+
+.gamification-achievement__title {
+  margin: 0;
+  font: 700 0.96rem/1.25 system-ui, sans-serif;
+}
+
+.gamification-achievement__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f5f7fb;
+  font: 600 0.74rem/1.1 system-ui, sans-serif;
+}
+
+.gamification-achievement__description,
+.gamification-achievement__requirement {
+  margin: 0;
+}
+
+.gamification-achievement__progress {
+  display: grid;
+  gap: 6px;
+}
+
+.gamification-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.gamification-history__item {
+  display: grid;
+  gap: 6px;
+}
+
+.gamification-history__row span {
+  color: rgba(245, 247, 251, 0.62);
+  font: 600 0.76rem/1.1 system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.gamification-skeleton {
+  border-radius: 14px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.12) 50%, rgba(255, 255, 255, 0.06) 100%);
+  background-size: 200% 100%;
+  animation: gamification-shimmer 1.5s ease-in-out infinite;
+}
+
+.gamification-skeleton--title {
+  height: 18px;
+  width: 72%;
+}
+
+.gamification-skeleton--line {
+  height: 12px;
+}
+
+.gamification-skeleton--card {
+  height: 88px;
+}
+
+@keyframes gamification-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
 @media (max-width: 900px) {
   #hud {
     flex-direction: column;
     align-items: stretch;
   }
 
-  #detail-panel {
+  #detail-panel,
+  #gamification-panel {
     left: 16px;
     right: 16px;
     width: auto;
+    max-height: 34vh;
+  }
+
+  #detail-panel {
     top: auto;
+    bottom: 320px;
+  }
+
+  #gamification-panel {
     bottom: 160px;
-    max-height: 42vh;
   }
 
   .timeline-panel {

--- a/frontend/static/js/api-client.js
+++ b/frontend/static/js/api-client.js
@@ -85,20 +85,45 @@
     return searchParams.toString();
   }
 
-  async function fetchJson(path) {
+  async function requestJson(path, options) {
+    const settings = options || {};
     const base = resolveBackendBaseUrl();
     const url = base ? `${base}${path}` : path;
-    const response = await fetch(url, {
-      headers: {
+    const headers = Object.assign(
+      {
         Accept: 'application/json',
       },
-    });
+      settings.headers || {},
+    );
+    const requestOptions = {
+      method: settings.method || 'GET',
+      headers,
+    };
 
-    if (!response.ok) {
-      throw new Error(`Request failed for ${url}: ${response.status}`);
+    if (settings.body !== undefined) {
+      requestOptions.body = typeof settings.body === 'string' ? settings.body : JSON.stringify(settings.body);
+      if (!requestOptions.headers['Content-Type'] && !requestOptions.headers['content-type']) {
+        requestOptions.headers['Content-Type'] = 'application/json';
+      }
     }
 
-    return response.json();
+    const response = await fetch(url, requestOptions);
+    const contentType = response.headers.get('content-type') || '';
+    const payload = contentType.includes('application/json') ? await response.json() : await response.text();
+
+    if (!response.ok) {
+      const message = payload && typeof payload === 'object' && payload.error ? payload.error : `Request failed for ${url}: ${response.status}`;
+      const error = new Error(message);
+      error.status = response.status;
+      error.payload = payload;
+      throw error;
+    }
+
+    return payload;
+  }
+
+  async function fetchJson(path) {
+    return requestJson(path, { method: 'GET' });
   }
 
   async function loadMapData() {
@@ -205,6 +230,53 @@
     };
   }
 
+  function buildGamificationHeaders(userId, displayName) {
+    const headers = {};
+    const resolvedUserId = String(userId || '').trim();
+    const resolvedDisplayName = String(displayName || '').trim();
+
+    if (resolvedUserId) {
+      headers['X-User-Id'] = resolvedUserId;
+    }
+
+    if (resolvedDisplayName) {
+      headers['X-User-Name'] = resolvedDisplayName;
+    }
+
+    return headers;
+  }
+
+  async function loadGamificationProfile(userId, options) {
+    const settings = options || {};
+    const resolvedUserId = String(userId || '').trim();
+    if (!resolvedUserId) {
+      throw new Error('userId is required');
+    }
+
+    return requestJson(`/api/user/${encodeURIComponent(resolvedUserId)}/profile`, {
+      method: 'GET',
+      headers: buildGamificationHeaders(resolvedUserId, settings.displayName),
+    });
+  }
+
+  async function recordTrip(payload) {
+    const requestPayload = payload || {};
+    return requestJson('/api/user/record-trip', {
+      method: 'POST',
+      headers: buildGamificationHeaders(requestPayload.userId || requestPayload.user_id, requestPayload.displayName),
+      body: requestPayload,
+    });
+  }
+
+  async function redeemDiscount(payload) {
+    const requestPayload = payload || {};
+    return requestJson('/api/user/redeem', {
+      method: 'POST',
+      headers: buildGamificationHeaders(requestPayload.userId || requestPayload.user_id, requestPayload.displayName),
+      body: requestPayload,
+    });
+  }
+
   function createVehiclePolling(options) {
     const settings = options || {};
     const intervalMs = Number.isFinite(settings.intervalMs) && settings.intervalMs > 0 ? settings.intervalMs : 2000;
@@ -266,6 +338,9 @@
     loadVehicleHistory,
     loadAllVehicleHistory,
     createVehiclePolling,
+    loadGamificationProfile,
+    recordTrip,
+    redeemDiscount,
     sampleData: () => cloneData(SAMPLE_DATA),
   };
 })(window);

--- a/frontend/static/js/gamification-manager.js
+++ b/frontend/static/js/gamification-manager.js
@@ -1,0 +1,546 @@
+(function (global) {
+  const STORAGE_USER_ID_KEY = 'xdei.gamification.userId';
+  const STORAGE_DISPLAY_NAME_KEY = 'xdei.gamification.displayName';
+
+  const ACHIEVEMENT_CATALOG = [
+    {
+      id: 'first_trip',
+      title: 'Primer viaje',
+      description: 'Consigue 10 puntos completando tu primer viaje.',
+      icon: '🚌',
+      requirementLabel: '10 puntos',
+      requirementType: 'points',
+      requirementValue: 10,
+    },
+    {
+      id: 'explorer_5',
+      title: 'Explorador',
+      description: 'Visita 5 paradas distintas para ampliar tu ruta.',
+      icon: '🗺️',
+      requirementLabel: '5 paradas',
+      requirementType: 'stops',
+      requirementValue: 5,
+    },
+    {
+      id: 'explorer_10',
+      title: 'Explorador avanzado',
+      description: 'Visita 10 paradas distintas y domina la red.',
+      icon: '🏆',
+      requirementLabel: '10 paradas',
+      requirementType: 'stops',
+      requirementValue: 10,
+    },
+  ];
+
+  const state = {
+    ready: false,
+    loading: false,
+    redeeming: false,
+    userId: '',
+    displayName: '',
+    profile: null,
+    error: '',
+    message: '',
+  };
+
+  const dom = {
+    panel: null,
+    body: null,
+    status: null,
+    userForm: null,
+    userIdInput: null,
+    displayNameInput: null,
+  };
+
+  function escapeHtml(value) {
+    return String(value === null || value === undefined ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatDateTime(value) {
+    if (!value) {
+      return 'Sin actividad reciente';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return String(value);
+    }
+
+    return new Intl.DateTimeFormat('es-ES', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  }
+
+  function getStoredValue(key) {
+    try {
+      return global.localStorage ? global.localStorage.getItem(key) || '' : '';
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function setStoredValue(key, value) {
+    try {
+      if (!global.localStorage) {
+        return;
+      }
+
+      if (!value) {
+        global.localStorage.removeItem(key);
+        return;
+      }
+
+      global.localStorage.setItem(key, value);
+    } catch (error) {
+      // Ignore storage failures in restricted browsers.
+    }
+  }
+
+  function getCurrentUserId() {
+    const globalValue = (global.GAMIFICATION_USER_ID || '').trim();
+    if (globalValue) {
+      return globalValue;
+    }
+
+    const storedValue = getStoredValue(STORAGE_USER_ID_KEY).trim();
+    if (storedValue) {
+      return storedValue;
+    }
+
+    return '';
+  }
+
+  function getCurrentDisplayName(userId) {
+    const globalValue = (global.GAMIFICATION_DISPLAY_NAME || '').trim();
+    if (globalValue) {
+      return globalValue;
+    }
+
+    const storedValue = getStoredValue(STORAGE_DISPLAY_NAME_KEY).trim();
+    if (storedValue) {
+      return storedValue;
+    }
+
+    return userId;
+  }
+
+  function resolveAchievementState(achievement, profile) {
+    const isUnlocked = Array.isArray(profile.achievements) && profile.achievements.includes(achievement.id);
+    let currentValue = 0;
+
+    if (achievement.requirementType === 'points') {
+      currentValue = Number(profile.totalPoints || 0);
+    } else if (achievement.requirementType === 'stops') {
+      currentValue = Array.isArray(profile.visitedStops) ? profile.visitedStops.length : 0;
+    }
+
+    return {
+      isUnlocked,
+      currentValue,
+      progress: achievement.requirementValue
+        ? Math.min(100, Math.round((currentValue / achievement.requirementValue) * 100))
+        : 0,
+    };
+  }
+
+  function getNextAchievement(profile) {
+    return ACHIEVEMENT_CATALOG.find((achievement) => !resolveAchievementState(achievement, profile).isUnlocked) || null;
+  }
+
+  function buildAchievementCard(achievement, profile) {
+    const status = resolveAchievementState(achievement, profile);
+    const statusLabel = status.isUnlocked ? 'Desbloqueado' : 'Bloqueado';
+    const progressText = status.isUnlocked
+      ? 'Completado'
+      : `${status.currentValue}/${achievement.requirementValue} ${achievement.requirementType === 'points' ? 'puntos' : 'paradas'}`;
+
+    return `
+      <article class="gamification-achievement ${status.isUnlocked ? 'gamification-achievement--unlocked' : ''}">
+        <div class="gamification-achievement__icon" aria-hidden="true">${escapeHtml(achievement.icon)}</div>
+        <div class="gamification-achievement__content">
+          <div class="gamification-achievement__meta">
+            <h4 class="gamification-achievement__title">${escapeHtml(achievement.title)}</h4>
+            <span class="gamification-achievement__badge">${escapeHtml(statusLabel)}</span>
+          </div>
+          <p class="gamification-achievement__description">${escapeHtml(achievement.description)}</p>
+          <div class="gamification-achievement__progress">
+            <div class="gamification-achievement__progress-track" aria-hidden="true">
+              <span style="width:${status.progress}%"></span>
+            </div>
+            <span class="gamification-achievement__progress-label">${escapeHtml(progressText)}</span>
+          </div>
+          <div class="gamification-achievement__requirement">Requisito: ${escapeHtml(achievement.requirementLabel)}</div>
+        </div>
+      </article>
+    `;
+  }
+
+  function buildRedeemedItem(discount) {
+    return `
+      <li class="gamification-history__item">
+        <div class="gamification-history__row">
+          <strong>${escapeHtml(discount.discountCode || 'Canje')}</strong>
+          <span>${escapeHtml(discount.status || 'redeemed')}</span>
+        </div>
+        <div class="gamification-history__meta">
+          Descuento: ${escapeHtml(discount.discountValue ?? 0)}
+        </div>
+        <div class="gamification-history__meta">Canjeado: ${escapeHtml(formatDateTime(discount.redeemedAt))}</div>
+        ${discount.validUntil ? `<div class="gamification-history__meta">Válido hasta: ${escapeHtml(formatDateTime(discount.validUntil))}</div>` : ''}
+      </li>
+    `;
+  }
+
+  function renderLoading() {
+    return `
+      <section class="gamification-section gamification-section--loading" aria-busy="true">
+        <div class="gamification-skeleton gamification-skeleton--title"></div>
+        <div class="gamification-skeleton gamification-skeleton--line"></div>
+        <div class="gamification-skeleton gamification-skeleton--line"></div>
+        <div class="gamification-skeleton gamification-skeleton--card"></div>
+        <div class="gamification-skeleton gamification-skeleton--card"></div>
+      </section>
+    `;
+  }
+
+  function renderEmpty() {
+    return `
+      <section class="gamification-section gamification-empty">
+        <h3 class="gamification-section__title">Carga tu perfil</h3>
+        <p class="gamification-empty__text">Introduce un usuario para ver sus puntos, logros y canjes disponibles.</p>
+      </section>
+    `;
+  }
+
+  function renderError() {
+    return `
+      <section class="gamification-section gamification-error" role="alert">
+        <h3 class="gamification-section__title">No se pudo cargar el perfil</h3>
+        <p class="gamification-empty__text">${escapeHtml(state.error || 'Error desconocido')}</p>
+      </section>
+    `;
+  }
+
+  function renderProfile(profile) {
+    const unlockedAchievements = Array.isArray(profile.achievements) ? profile.achievements : [];
+    const visitedStops = Array.isArray(profile.visitedStops) ? profile.visitedStops : [];
+    const redeemedDiscounts = Array.isArray(profile.redeemedDiscounts) ? profile.redeemedDiscounts : [];
+    const nextAchievement = getNextAchievement(profile);
+    const nextAchievementStatus = nextAchievement ? resolveAchievementState(nextAchievement, profile) : null;
+    const nextProgressText = nextAchievement
+      ? `${nextAchievementStatus.currentValue}/${nextAchievement.requirementValue} ${nextAchievement.requirementType === 'points' ? 'puntos' : 'paradas'}`
+      : 'Todos los logros desbloqueados';
+
+    return `
+      <section class="gamification-section">
+        <div class="gamification-summary">
+          <div class="gamification-summary__card">
+            <span class="gamification-summary__label">Puntos</span>
+            <strong class="gamification-summary__value">${escapeHtml(profile.totalPoints || 0)}</strong>
+          </div>
+          <div class="gamification-summary__card">
+            <span class="gamification-summary__label">Logros</span>
+            <strong class="gamification-summary__value">${escapeHtml(unlockedAchievements.length)}</strong>
+          </div>
+          <div class="gamification-summary__card">
+            <span class="gamification-summary__label">Paradas</span>
+            <strong class="gamification-summary__value">${escapeHtml(visitedStops.length)}</strong>
+          </div>
+          <div class="gamification-summary__card">
+            <span class="gamification-summary__label">Canjes</span>
+            <strong class="gamification-summary__value">${escapeHtml(redeemedDiscounts.length)}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section class="gamification-section">
+        <h3 class="gamification-section__title">Progreso</h3>
+        <div class="gamification-progress">
+          <div class="gamification-progress__header">
+            <span>${escapeHtml(nextAchievement ? nextAchievement.title : 'Ruta completada')}</span>
+            <span>${escapeHtml(nextProgressText)}</span>
+          </div>
+          <div class="gamification-progress__track" aria-hidden="true">
+            <span style="width:${escapeHtml(nextAchievementStatus ? nextAchievementStatus.progress : 100)}%"></span>
+          </div>
+          <p class="gamification-progress__hint">
+            ${escapeHtml(nextAchievement ? nextAchievement.description : 'Ya has desbloqueado todos los hitos disponibles en esta versión.')}
+          </p>
+        </div>
+      </section>
+
+      <section class="gamification-section">
+        <h3 class="gamification-section__title">Logros</h3>
+        <div class="gamification-achievement-grid">
+          ${ACHIEVEMENT_CATALOG.map((achievement) => buildAchievementCard(achievement, profile)).join('')}
+        </div>
+      </section>
+
+      <section class="gamification-section">
+        <h3 class="gamification-section__title">Canjear puntos</h3>
+        <form id="gamification-redeem-form" class="gamification-form">
+          <div class="gamification-form__grid">
+            <label class="gamification-field">
+              <span>Código</span>
+              <input name="discountCode" type="text" placeholder="BUS10" required />
+            </label>
+            <label class="gamification-field">
+              <span>Valor descuento</span>
+              <input name="discountValue" type="number" min="0" step="1" placeholder="10" />
+            </label>
+            <label class="gamification-field">
+              <span>Coste en puntos</span>
+              <input name="pointsCost" type="number" min="1" step="1" placeholder="12" required />
+            </label>
+            <label class="gamification-field">
+              <span>Válido hasta</span>
+              <input name="validUntil" type="datetime-local" />
+            </label>
+          </div>
+          <button class="gamification-button" type="submit" ${state.redeeming ? 'disabled' : ''}>${state.redeeming ? 'Canjeando…' : 'Canjear descuento'}</button>
+        </form>
+      </section>
+
+      <section class="gamification-section">
+        <h3 class="gamification-section__title">Historial de canjes</h3>
+        ${redeemedDiscounts.length
+          ? `<ul class="gamification-history">${redeemedDiscounts.map((discount) => buildRedeemedItem(discount)).join('')}</ul>`
+          : '<p class="gamification-empty__text">Aún no has realizado canjes.</p>'}
+      </section>
+    `;
+  }
+
+  function renderStatusText() {
+    if (state.loading) {
+      return 'Cargando perfil…';
+    }
+
+    if (state.redeeming) {
+      return 'Procesando canje…';
+    }
+
+    if (state.message) {
+      return state.message;
+    }
+
+    if (state.error) {
+      return 'Perfil con incidencias';
+    }
+
+    return state.profile ? `Perfil listo · ${state.userId}` : 'Listo para cargar';
+  }
+
+  function render() {
+    if (!dom.panel || !dom.body || !dom.status) {
+      return;
+    }
+
+    dom.status.textContent = renderStatusText();
+    dom.panel.classList.toggle('gamification-panel--loading', Boolean(state.loading));
+    dom.panel.classList.toggle('gamification-panel--error', Boolean(state.error));
+
+    let content = '';
+    if (state.loading) {
+      content = renderLoading();
+    } else if (state.error) {
+      content = renderError();
+    } else if (!state.profile) {
+      content = renderEmpty();
+    } else {
+      content = renderProfile(state.profile);
+    }
+
+    dom.body.innerHTML = `
+      <section class="gamification-section">
+        <form id="gamification-user-form" class="gamification-user-form" autocomplete="off">
+          <label class="gamification-field">
+            <span>Usuario</span>
+            <input id="gamification-user-id" name="userId" type="text" placeholder="alice" value="${escapeHtml(state.userId)}" required />
+          </label>
+          <label class="gamification-field">
+            <span>Nombre</span>
+            <input id="gamification-display-name" name="displayName" type="text" placeholder="Alice" value="${escapeHtml(state.displayName)}" />
+          </label>
+          <button class="gamification-button gamification-button--ghost" type="submit">Cargar perfil</button>
+        </form>
+      </section>
+      ${state.message ? `<section class="gamification-section gamification-message" role="status">${escapeHtml(state.message)}</section>` : ''}
+      ${content}
+    `;
+
+    dom.userForm = dom.body.querySelector('#gamification-user-form');
+    dom.userIdInput = dom.body.querySelector('#gamification-user-id');
+    dom.displayNameInput = dom.body.querySelector('#gamification-display-name');
+  }
+
+  async function loadProfile(userId, displayName) {
+    const resolvedUserId = String(userId || '').trim();
+    if (!resolvedUserId) {
+      state.error = 'Debes indicar un usuario.';
+      state.profile = null;
+      state.loading = false;
+      state.message = '';
+      render();
+      return;
+    }
+
+    state.loading = true;
+    state.error = '';
+    state.message = '';
+    state.userId = resolvedUserId;
+    state.displayName = String(displayName || '').trim() || resolvedUserId;
+    render();
+
+    setStoredValue(STORAGE_USER_ID_KEY, state.userId);
+    setStoredValue(STORAGE_DISPLAY_NAME_KEY, state.displayName);
+
+    try {
+      const profile = await global.MapApiClient.loadGamificationProfile(state.userId, {
+        displayName: state.displayName,
+      });
+      state.profile = profile;
+      state.message = `Perfil cargado: ${profile.displayName || state.displayName}`;
+    } catch (error) {
+      state.profile = null;
+      state.error = error && error.message ? error.message : 'No se pudo cargar el perfil';
+    } finally {
+      state.loading = false;
+      render();
+    }
+  }
+
+  async function submitRedeem(formElement) {
+    const formData = new FormData(formElement);
+    const discountCode = String(formData.get('discountCode') || '').trim();
+    const discountValueRaw = String(formData.get('discountValue') || '').trim();
+    const pointsCostRaw = String(formData.get('pointsCost') || '').trim();
+    const validUntilRaw = String(formData.get('validUntil') || '').trim();
+
+    if (!discountCode) {
+      state.error = 'El código de descuento es obligatorio.';
+      render();
+      return;
+    }
+
+    state.redeeming = true;
+    state.error = '';
+    state.message = '';
+    render();
+
+    try {
+      const validUntil = validUntilRaw ? new Date(validUntilRaw) : null;
+      const result = await global.MapApiClient.redeemDiscount({
+        userId: state.userId,
+        displayName: state.displayName,
+        discountCode,
+        discountValue: discountValueRaw ? Number(discountValueRaw) : 0,
+        pointsCost: pointsCostRaw ? Number(pointsCostRaw) : undefined,
+        validUntil: validUntil && !Number.isNaN(validUntil.getTime()) ? validUntil.toISOString() : undefined,
+      });
+
+      state.profile = result.profile;
+      state.message = `Canje realizado: ${result.redemption.discountCode}`;
+      formElement.reset();
+    } catch (error) {
+      state.error = error && error.message ? error.message : 'No se pudo canjear el descuento';
+    } finally {
+      state.redeeming = false;
+      render();
+    }
+  }
+
+  function handlePanelSubmit(event) {
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+
+    if (form.id === 'gamification-user-form') {
+      event.preventDefault();
+      const userId = form.querySelector('#gamification-user-id')?.value || '';
+      const displayName = form.querySelector('#gamification-display-name')?.value || '';
+      loadProfile(userId, displayName);
+      return;
+    }
+
+    if (form.id === 'gamification-redeem-form') {
+      event.preventDefault();
+      submitRedeem(form);
+    }
+  }
+
+  function hydrateStateFromStorage() {
+    state.userId = getCurrentUserId();
+    state.displayName = getCurrentDisplayName(state.userId);
+  }
+
+  function init() {
+    if (state.ready) {
+      return;
+    }
+
+    dom.panel = document.getElementById('gamification-panel');
+    dom.body = document.getElementById('gamification-panel-body');
+    dom.status = document.getElementById('gamification-status');
+
+    if (!dom.panel || !dom.body || !dom.status) {
+      return;
+    }
+
+    hydrateStateFromStorage();
+    dom.panel.addEventListener('submit', handlePanelSubmit);
+    state.ready = true;
+    render();
+
+    if (state.userId) {
+      loadProfile(state.userId, state.displayName);
+    }
+  }
+
+  function refresh() {
+    if (!state.userId) {
+      return Promise.resolve();
+    }
+
+    return loadProfile(state.userId, state.displayName);
+  }
+
+  function setUser(userId, displayName) {
+    state.userId = String(userId || '').trim();
+    state.displayName = String(displayName || '').trim() || state.userId;
+    setStoredValue(STORAGE_USER_ID_KEY, state.userId);
+    setStoredValue(STORAGE_DISPLAY_NAME_KEY, state.displayName);
+    render();
+  }
+
+  global.GamificationManager = {
+    init,
+    refresh,
+    setUser,
+    loadProfile,
+    getState: function () {
+      return {
+        ready: state.ready,
+        loading: state.loading,
+        redeeming: state.redeeming,
+        userId: state.userId,
+        displayName: state.displayName,
+        profile: state.profile,
+        error: state.error,
+        message: state.message,
+      };
+    },
+  };
+
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})(window);


### PR DESCRIPTION
## Summary\n- Adds a dedicated gamification panel for profile, achievements, and discount redemption.\n- Extends the frontend API client with profile, trip, and redeem calls using the existing auth headers.\n- Introduces a self-contained gamification manager with loading, error, empty, and success states.\n\n## Validation\n- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.3, pluggy-1.6.0
rootdir: /home/lucia/xdei/p3
plugins: mock-3.12.0
collected 6 items

backend/tests/test_gamification_api.py ......                            [100%]

============================== 6 passed in 0.15s ===============================\n- \n- \n- \n\n## Notes\n- No merge requested; this PR is ready for review.