### PR TITLE
Configurar Grafana con CrateDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Servicios expuestos (puertos locales):
 - Backend (stub): `8000` (`/health`)
 - Frontend (stub): `8080`
 
+Grafana se arranca con un datasource de CrateDB ya provisionado, usando el driver PostgreSQL contra `crate:5432` dentro de la red de Docker Compose.
+
 Nota de modelado de datos:
 Las entidades NGSI-LD deben alinearse con los esquemas estándar de `dataModel.UrbanMobility` de FIWARE (PublicTransportStop, PublicTransportRoute, Vehicle, etc.). Consultar `data_model.md`.
 

--- a/config/grafana/provisioning/datasources/cratedb.yaml
+++ b/config/grafana/provisioning/datasources/cratedb.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+datasources:
+  - name: CrateDB
+    uid: cratedb
+    type: postgres
+    access: proxy
+    url: crate:5432
+    database: doc
+    user: crate
+    isDefault: false
+    editable: false
+    jsonData:
+      sslmode: disable
+      postgresVersion: 1600
+      timescaledb: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
+      - ./config/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]


### PR DESCRIPTION
## Summary\n- Provisions a Grafana datasource for CrateDB using the built-in PostgreSQL datasource.\n- Mounts repo-managed Grafana provisioning into the container so the datasource is created on startup.\n- Documents the auto-provisioned setup in the README.\n\n## Validation\n- git diff --cached --check\n\n## Notes\n- Docker is not available in this WSL environment, so I could not run a live Compose smoke test.\n- The PR intentionally excludes unrelated local changes that remain unstaged in docker-compose.yml.