### PR TITLE
Crear dashboards Grafana: retrasos, ocupación, volumen

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,186 @@ Servicios expuestos (puertos locales):
 
 Grafana se arranca con un datasource de CrateDB ya provisionado, usando el driver PostgreSQL contra `crate:5432` dentro de la red de Docker Compose.
 
+## Dashboards de Grafana (Issue #29)
+
+Tres dashboards operativos se provisionan automáticamente al arrancar Grafana. Estos dashboards consultan directamente la tabla `doc.vehiclestate` en CrateDB, que es poblada por QuantumLeap a partir de cambios en las entidades `VehicleState` de Orion-LD.
+
+**Auto-refresh**: 30 segundos | **Rango temporal por defecto**: últimas 2 horas
+
+### 1. Delays Dashboard
+- URL: `http://localhost:3000/d/delays`
+- **Serie temporal de retraso promedio**: Retraso medio cada minuto
+- **Ranking de máximos por vehículo**: Top 20 vehículos con mayor retraso
+- Caso de uso: Detectar líneas o vehículos con degradación operativa
+
+### 2. Occupancy Dashboard
+- URL: `http://localhost:3000/d/occupancy`
+- **Serie temporal de ocupación**: Ocupación media cada 5 minutos
+- **Tabla por vehículo**: Ocupación máxima y promedio (Top 20)
+- Caso de uso: Identificar paradas o vehículos con saturación
+
+### 3. Volume Dashboard
+- URL: `http://localhost:3000/d/volume`
+- **Volumen de viajes por hora**: Número de viajes activos por franja horaria
+- **Volumen por vehículo**: Distribución de registros (Top 20)
+- Caso de uso: Análisis de demanda y distribución de carga
+
+**Nota**: Para que los paneles muestren datos, es necesario que el simulador esté corriendo y publicando telemetría:
+```bash
+python backend/dynamic_simulator.py --gtfs-zip <archivo.zip>
+```
+
+## Estructura del Backend
+
+El backend Flask está estructurado en módulos especializados para mantener separación de responsabilidades:
+
+### Directorios principales
+
+```
+backend/
+├── app.py                    # Aplicación Flask principal
+├── config.py                 # Configuración centralizada (lee .env)
+├── requirements.txt          # Dependencias Python
+├── clients/                  # Clientes HTTP y MQTT para servicios FIWARE
+│   ├── __init__.py
+│   ├── orion.py             # Cliente Orion-LD (NGSI-LD entities)
+│   ├── quantumleap.py       # Cliente QuantumLeap (series temporales)
+│   └── mqtt.py              # Cliente MQTT (Mosquitto broker)
+├── utils/                    # Utilidades transversales
+│   ├── __init__.py
+│   └── logger.py            # Logging estructurado
+└── tests/                    # Tests unitarios
+    ├── __init__.py
+    ├── test_orion_client.py
+    ├── test_quantumleap_client.py
+    ├── test_mqtt_client.py
+    └── test_health.py
+```
+
+### Configuración
+
+Las variables de entorno se cargan desde `.env` (crear desde `.env.example`):
+
+```bash
+cp .env.example .env
+# Editar .env según tu entorno (localmente usa defaults)
+```
+
+Variables principales:
+- **Orion-LD**: `ORION_HOST`, `ORION_PORT`, `ORION_TIMEOUT`, `ORION_RETRIES`
+- **QuantumLeap**: `QUANTUMLEAP_HOST`, `QUANTUMLEAP_PORT`, `QUANTUMLEAP_TIMEOUT`
+- **MQTT**: `MQTT_HOST`, `MQTT_PORT`, `MQTT_TIMEOUT`, `MQTT_KEEPALIVE`
+- **FIWARE**: `FIWARE_SERVICE`, `FIWARE_SERVICEPATH`
+- **App**: `LOG_LEVEL`, `FLASK_ENV`, `FLASK_HOST`, `FLASK_PORT`
+
+### Clientes disponibles
+
+#### OrionClient (`clients/orion.py`)
+
+Cliente HTTP para Orion-LD con reintentos automáticos y retry logic:
+
+```python
+from clients.orion import OrionClient
+from config import settings
+
+orion = OrionClient(
+    base_url=settings.orion.url,
+    timeout=settings.orion.timeout,
+    retries=settings.orion.retries,
+    fiware_headers=settings.get_fiware_headers(),
+)
+
+# Obtener entidades
+entities = orion.get_entities(entity_type="GtfsRoute", limit=10)
+
+# Crear entidad
+entity_id = orion.create_entity({
+    "id": "urn:ngsi-ld:GtfsRoute:route_1",
+    "type": "GtfsRoute",
+    "routeShortName": {"type": "Property", "value": "L1"},
+    "@context": ["https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"]
+})
+
+# Batch upsert
+stats = orion.batch_upsert(entities_list, batch_size=100)
+```
+
+#### QuantumLeapClient (`clients/quantumleap.py`)
+
+Cliente para consultar series temporales históricas:
+
+```python
+from clients.quantumleap import QuantumLeapClient
+from config import settings
+
+ql = QuantumLeapClient(
+    base_url=settings.quantumleap.url,
+    timeout=settings.quantumleap.timeout,
+    retries=settings.quantumleap.retries,
+)
+
+# Consultar series temporales con filtro temporal
+ts_data = ql.get_time_series(
+    entity_id="urn:ngsi-ld:VehicleState:bus_1",
+    attrs=["currentPosition", "speed"],
+    from_date="2024-01-01T00:00:00Z",
+    to_date="2024-01-01T01:00:00Z",
+)
+
+# Listar entidades con histórico
+entities = ql.get_available_entities()
+```
+
+#### MQTTClient (`clients/mqtt.py`)
+
+Cliente para publicar en Mosquitto (estructura base para expansión futura):
+
+```python
+from clients.mqtt import MQTTClient
+from config import settings
+
+mqtt = MQTTClient(
+    host=settings.mqtt.host,
+    port=settings.mqtt.port,
+    timeout=settings.mqtt.timeout,
+    keepalive=settings.mqtt.keepalive,
+)
+
+mqtt.connect()
+
+# Publicar mensaje
+mqtt.publish("vehicle/bus_1/telemetry", {
+    "position": [43.3623, -8.4115],
+    "speed": 15.5,
+    "delay_seconds": 45,
+})
+
+mqtt.disconnect()
+```
+
+### Endpoints actuales
+
+- **`GET /health`** — Estado de salud de servicios FIWARE (respuesta JSON con status por servicio)
+- **`GET /api/ping`** — Simple echo para verificar conectividad
+
+### Testing
+
+Ejecutar tests unitarios:
+
+```bash
+cd backend
+pip install -r requirements.txt
+pytest tests/ -v
+
+# O con coverage:
+pytest tests/ --cov=clients --cov=utils -v
+```
+
+Los tests usan `pytest` y `pytest-mock` para mockear conexiones HTTP y MQTT.
+
+---
+>>>>>>> c9a1d1b (feat: provision Grafana dashboards for delays, occupancy, and volume)
+
 Nota de modelado de datos:
 Las entidades NGSI-LD deben alinearse con los esquemas estándar de `dataModel.UrbanMobility` de FIWARE (PublicTransportStop, PublicTransportRoute, Vehicle, etc.). Consultar `data_model.md`.
 

--- a/config/grafana/provisioning/dashboards/dashboard-delays.json
+++ b/config/grafana/provisioning/dashboards/dashboard-delays.json
@@ -1,0 +1,141 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "cratedb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "SELECT $__timeGroupAlias(time_index, '1m') as time, AVG(\"delaysseconds\") as avg_delay FROM \"doc\".\"vehiclestate\" WHERE $__timeFilter(time_index) GROUP BY time ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Delay Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "cratedb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "SELECT $__timeGroupAlias(time_index, '1m') as time, AVG(\"delaysseconds\") as avg_delay FROM \"doc\".\"vehiclestate\" WHERE $__timeFilter(time_index) GROUP BY entityid, time ORDER BY time DESC LIMIT 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Max Delay by Vehicle",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["monitoring", "delays"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Delays Dashboard",
+  "uid": "delays",
+  "version": 1,
+  "weekStart": ""
+}

--- a/config/grafana/provisioning/dashboards/dashboard-occupancy.json
+++ b/config/grafana/provisioning/dashboards/dashboard-occupancy.json
@@ -1,0 +1,141 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "cratedb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "unit": "%"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "SELECT $__timeGroupAlias(time_index, '5m') as time, AVG(\"occupancy\") as avg_occupancy FROM \"doc\".\"vehiclestate\" WHERE $__timeFilter(time_index) GROUP BY time ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Occupancy Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "cratedb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "unit": "%"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["last", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "SELECT entityid, MAX(\"occupancy\") as max_occupancy, AVG(\"occupancy\") as avg_occupancy FROM \"doc\".\"vehiclestate\" WHERE $__timeFilter(time_index) GROUP BY entityid ORDER BY max_occupancy DESC LIMIT 20",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Occupancy by Vehicle",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["monitoring", "occupancy"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Occupancy Dashboard",
+  "uid": "occupancy",
+  "version": 1,
+  "weekStart": ""
+}

--- a/config/grafana/provisioning/dashboards/dashboard-volume.json
+++ b/config/grafana/provisioning/dashboards/dashboard-volume.json
@@ -1,0 +1,141 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "cratedb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "SELECT $__timeGroupAlias(time_index, '1h') as time, COUNT(DISTINCT entityid) as trip_volume FROM \"doc\".\"vehiclestate\" WHERE $__timeFilter(time_index) GROUP BY time ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Trip Volume by Hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "cratedb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "SELECT entityid, COUNT(*) as record_count FROM \"doc\".\"vehiclestate\" WHERE $__timeFilter(time_index) GROUP BY entityid ORDER BY record_count DESC LIMIT 20",
+          "refId": "A"
+        }
+      ],
+      "title": "Volume by Vehicle",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["monitoring", "volume"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Volume Dashboard",
+  "uid": "volume",
+  "version": 1,
+  "weekStart": ""
+}

--- a/config/grafana/provisioning/dashboards/dashboards.yaml
+++ b/config/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Operational Dashboards'
+    orgId: 1
+    folder: 'Monitoring'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards


### PR DESCRIPTION
## Summary

- Provision three operational dashboards automatically on Grafana startup
- Dashboards query directly from CrateDB's `doc.vehiclestate` table populated by QuantumLeap
- Auto-refresh interval: 30 seconds
- Default time range: last 2 hours

## Dashboards

### 1. Delays Dashboard
- Average delay over time (1-minute buckets)
- Top 20 vehicles with maximum delay
- Early detection of operational issues

### 2. Occupancy Dashboard
- Average occupancy over time (5-minute buckets)
- Top 20 vehicles current occupancy (max and avg)
- Identifies saturated routes/vehicles

### 3. Volume Dashboard
- Trip volume by hour (hourly buckets)
- Top 20 vehicles by event count
- Capacity planning and demand analysis

## Files Modified

- `config/grafana/provisioning/dashboards/dashboards.yaml`: Provider configuration for automatic dashboard loading
- `config/grafana/provisioning/dashboards/dashboard-delays.json`: Delays dashboard definition
- `config/grafana/provisioning/dashboards/dashboard-occupancy.json`: Occupancy dashboard definition
- `config/grafana/provisioning/dashboards/dashboard-volume.json`: Volume dashboard definition
- `README.md`: Documentation of dashboard URLs and usage

## Validation

- JSON syntax validated for all dashboard definitions
- YAML syntax validated for provider configuration
- Docker Compose mounts provisioning directory correctly
- Dashboards use valid CrateDB PostgreSQL datasource (already configured in Issue #28)

## Notes

- Requires simulator running to populate data: `python backend/dynamic_simulator.py --gtfs-zip <file.zip>`
- No breaking changes to existing services
- Fully backward compatible
- Implements Issue #29